### PR TITLE
Remove legacy per-text rotation code from text3d.js

### DIFF
--- a/docs/text-placement-spec.md
+++ b/docs/text-placement-spec.md
@@ -90,9 +90,7 @@ For each candidate rectangle, the algorithm tries every combination of:
 
 - **Line count**: 1 to `MAX_TEXT_LINES` (currently **4**, or word count if fewer)
 - **Word grouping**: all sequential assignments of words to lines for that line count
-- **Text rotation**:
-  - `[0°]` when `TEXT_ORIENTATION_FIXED`
-  - `[0°, 90°]` when `TEXT_ORIENTATION_AUTO`
+- **Text rotation**: always `0°` (horizontal text on the already-rotated model)
 
 Each layout is rendered, scaled to fit the candidate rectangle, and scored.
 

--- a/src/model.js
+++ b/src/model.js
@@ -10,8 +10,6 @@ import {
   DEFAULT_TEXT_POSITION_RANK,
   normalizeTextPositionRank,
   TEXT_HEIGHT_MM,
-  TEXT_ORIENTATION_AUTO,
-  TEXT_ORIENTATION_FIXED,
 } from './text3d.js';
 
 let textPlacementCache = { token: null, byOrientation: new Map(), resolvedAutoDeg: null };
@@ -598,14 +596,11 @@ function selectAutoOrientation(outlinePoints, basePlate, projectedNodes, trackNa
     try {
       const scale = computeScale(rotatedBp);
       const ranked = computeRankedTextPlacements(scoringText, rotatedOutline, rotatedBp, scale, {
-        textOrientationMode: TEXT_ORIENTATION_FIXED,
         allOutlinePoints,
       });
       placementsMap?.set(deg, ranked);
       if (ranked) {
-        const chosenOrientation = ranked.orientationResults.find(o => o.rotation === 0)
-          ?? ranked.orientationResults[0];
-        const best = chosenOrientation?.placements[0];
+        const best = ranked.placements[0];
         if (best?.layout?.lineBounds?.length) {
           const { candidate, layout } = best;
           const offsetY = candidate.bounds.minY
@@ -644,7 +639,6 @@ export function buildTrackModel({
   secondaryProjectedNodes = [],
   primaryOrientationDeg = undefined,
   orientationDeg = undefined,
-  textOrientationMode = undefined,
   textPositionRank = DEFAULT_TEXT_POSITION_RANK,
   placementCacheToken = null,
 }) {
@@ -685,9 +679,6 @@ export function buildTrackModel({
     resolvedOrientationDeg = normalizedPrimaryOrientationDeg;
   }
 
-  // Text orientation is always fixed: the model is already rotated to the correct orientation,
-  // so text should be placed right-side-up on the rotated model.
-  const resolvedTextOrientationMode = textOrientationMode ?? TEXT_ORIENTATION_FIXED;
   const resolvedTextPositionRank = normalizeTextPositionRank(textPositionRank);
   const orientedGeometry = orientTrackGeometry({
     outlinePoints,
@@ -740,7 +731,7 @@ export function buildTrackModel({
         orientedGeometry.outlinePoints,
         effectiveBasePlate,
         scale,
-        { textOrientationMode: resolvedTextOrientationMode, allOutlinePoints },
+        { allOutlinePoints },
       );
       if (cacheActive) {
         textPlacementCache.byOrientation.set(resolvedOrientationDeg, rankedPlacements);
@@ -750,7 +741,6 @@ export function buildTrackModel({
 
   const textTriangles = buildTextMeshFromRankedPlacements(rankedPlacements, {
     textPositionRank: resolvedTextPositionRank,
-    textOrientationMode: resolvedTextOrientationMode,
     baseThickness: BASE_THICKNESS_MM,
     textHeight: TEXT_HEIGHT_MM,
   });
@@ -763,7 +753,6 @@ export function buildTrackModel({
     textTriangleCount: textTriangles.length,
     scale,
     primaryOrientationDeg: normalizedPrimaryOrientationDeg,
-    textOrientationMode: resolvedTextOrientationMode,
     textPositionRank: resolvedTextPositionRank,
     orientationDeg: orientedGeometry.orientationDeg,
     outlinePoints: orientedGeometry.outlinePoints,

--- a/src/text3d.js
+++ b/src/text3d.js
@@ -4,8 +4,6 @@ import opentype from 'opentype.js';
 import { LABEL_FONT_BASE64 } from './label-font-data.js';
 
 export const TEXT_HEIGHT_MM = 0.8;
-export const TEXT_ORIENTATION_AUTO = 'auto';
-export const TEXT_ORIENTATION_FIXED = 'fixed';
 export const DEFAULT_TEXT_POSITION_RANK = 1;
 const CURVE_SEGMENTS = 8;
 const MIN_TEXT_HEIGHT_MM = 2;
@@ -517,15 +515,6 @@ function translateAndScaleBounds(bounds, scale, offsetX, offsetY) {
   };
 }
 
-function rotateBounds90(bounds) {
-  return polygonBounds([
-    { x: -bounds.minY, y: bounds.minX },
-    { x: -bounds.minY, y: bounds.maxX },
-    { x: -bounds.maxY, y: bounds.maxX },
-    { x: -bounds.maxY, y: bounds.minX },
-  ]);
-}
-
 function normalizeBoundsListToOrigin(boundsList) {
   const combined = polygonBounds(boundsList.flatMap(bounds => [
     { x: bounds.minX, y: bounds.minY },
@@ -938,13 +927,6 @@ function normalizeContoursToOrigin(contours) {
   };
 }
 
-function rotateContours90(contours) {
-  return contours.map(contour => contour.map(point => ({
-    x: -point.y,
-    y: point.x,
-  })));
-}
-
 function createSequentialLineGrouping(words, breakpoints) {
   const lines = [];
   let start = 0;
@@ -1127,14 +1109,6 @@ function computeCentralityMultiplier(centreDistance) {
   return 1.0 - 0.04 * clamp(centreDistance, 0, 1);
 }
 
-function normalizeTextOrientationMode(value) {
-  return value === TEXT_ORIENTATION_FIXED ? TEXT_ORIENTATION_FIXED : TEXT_ORIENTATION_AUTO;
-}
-
-function getTextRotationCandidates(textOrientationMode) {
-  return normalizeTextOrientationMode(textOrientationMode) === TEXT_ORIENTATION_FIXED ? [0] : [0, 90];
-}
-
 function scoreTextFit(rect, layout, candidate = {}, clearanceContext = null) {
   const fittedWidth = layout.fittedWidth;
   const fittedHeight = layout.fittedHeight;
@@ -1174,7 +1148,7 @@ export function __debugCompareRankedTextPlacements(a, b) {
   return compareRankedTextPlacements(a, b);
 }
 
-function fitTextToRectangleForRotation(text, font, rect, rotation, cache) {
+function fitTextToRectangle(text, font, rect, cache) {
   const words = String(text).split(/\s+/u).filter(Boolean);
   if (!words.length) {
     return [];
@@ -1191,16 +1165,9 @@ function fitTextToRectangleForRotation(text, font, rect, rotation, cache) {
         continue;
       }
 
-      const oriented = rotation === 0
-        ? multiline
-        : {
-          ...multiline,
-          ...normalizeContoursToOrigin(rotateContours90(multiline.contours)),
-          lineBounds: normalizeBoundsListToOrigin(multiline.lineBounds.map(rotateBounds90)),
-        };
       const fittedScale = Math.min(
-        rect.width / oriented.bounds.width,
-        rect.height / oriented.bounds.height,
+        rect.width / multiline.bounds.width,
+        rect.height / multiline.bounds.height,
         MAX_PREFERRED_HEIGHT_MM / multiline.averageLineHeight,
       );
 
@@ -1208,16 +1175,15 @@ function fitTextToRectangleForRotation(text, font, rect, rotation, cache) {
         continue;
       }
 
-      const fittedWidth = oriented.bounds.width * fittedScale;
-      const fittedHeight = oriented.bounds.height * fittedScale;
+      const fittedWidth = multiline.bounds.width * fittedScale;
+      const fittedHeight = multiline.bounds.height * fittedScale;
       layouts.push({
         text: multiline.text,
         lines: multiline.lines,
-        rotation,
         scale: fittedScale,
-        bounds: oriented.bounds,
-        contours: oriented.contours,
-        lineBounds: oriented.lineBounds,
+        bounds: multiline.bounds,
+        contours: multiline.contours,
+        lineBounds: multiline.lineBounds,
         fittedWidth,
         fittedHeight,
         averageLineHeight: multiline.averageLineHeight,
@@ -1232,8 +1198,8 @@ function fitTextToRectangleForRotation(text, font, rect, rotation, cache) {
   return layouts;
 }
 
-function findBestLayoutForLocation(text, font, candidate, rotation, cache, clearanceContext = null) {
-  const layouts = fitTextToRectangleForRotation(text, font, candidate.bounds, rotation, cache);
+function findBestLayoutForLocation(text, font, candidate, cache, clearanceContext = null) {
+  const layouts = fitTextToRectangle(text, font, candidate.bounds, cache);
   if (!layouts.length) return null;
 
   let bestLayout = null;
@@ -1250,30 +1216,20 @@ function findBestLayoutForLocation(text, font, candidate, rotation, cache, clear
   return bestLayout ? { layout: { ...bestLayout, score: bestScore }, score: bestScore } : null;
 }
 
-function rankTextPlacements(text, font, candidates, textOrientationMode = TEXT_ORIENTATION_AUTO, clearanceContext = null) {
+function rankTextPlacements(text, font, candidates, clearanceContext = null) {
   const cache = new Map();
-  const rotations = getTextRotationCandidates(textOrientationMode);
 
-  const orientationResults = rotations.map(rotation => {
-    const locationResults = candidates
-      .map((candidate, candidateIndex) => {
-        const best = findBestLayoutForLocation(text, font, candidate, rotation, cache, clearanceContext);
-        if (!best) return null;
-        return { candidate, candidateIndex, layout: best.layout, score: best.score };
-      })
-      .filter(Boolean);
+  const locationResults = candidates
+    .map((candidate, candidateIndex) => {
+      const best = findBestLayoutForLocation(text, font, candidate, cache, clearanceContext);
+      if (!best) return null;
+      return { candidate, candidateIndex, layout: best.layout, score: best.score };
+    })
+    .filter(Boolean);
 
-    locationResults.sort(compareRankedTextPlacements);
+  locationResults.sort(compareRankedTextPlacements);
 
-    return {
-      rotation,
-      placements: locationResults.slice(0, 3),
-      topScore: locationResults.length > 0 ? locationResults[0].score : -Infinity,
-    };
-  });
-
-  orientationResults.sort((a, b) => b.topScore - a.topScore);
-  return orientationResults;
+  return locationResults.slice(0, 3);
 }
 
 function computeTextPlacement(text, outlinePoints, basePlate, scale, options = {}) {
@@ -1299,33 +1255,21 @@ function computeTextPlacement(text, outlinePoints, basePlate, scale, options = {
     originX: scaledBasePlate.minX,
     originY: scaledBasePlate.minY,
   };
-  const orientationResults = rankTextPlacements(
+  const placements = rankTextPlacements(
     normalizedText,
     font,
     candidates,
-    options.textOrientationMode,
     clearanceContext,
   );
-  if (!orientationResults.length) {
-    return null;
-  }
-
-  let chosenOrientation;
-  if (normalizeTextOrientationMode(options.textOrientationMode) === TEXT_ORIENTATION_FIXED) {
-    chosenOrientation = orientationResults.find(o => o.rotation === 0) ?? orientationResults[0];
-  } else {
-    chosenOrientation = orientationResults[0];
-  }
-
-  if (!chosenOrientation.placements.length) {
+  if (!placements.length) {
     return null;
   }
 
   const placementRank = Math.min(
     normalizeTextPositionRank(options.textPositionRank) - 1,
-    chosenOrientation.placements.length - 1,
+    placements.length - 1,
   );
-  const selected = chosenOrientation.placements[placementRank];
+  const selected = placements[placementRank];
   const { candidate, candidateIndex, layout, score } = selected;
   const offsetX = candidate.bounds.minX + (candidate.bounds.width - layout.fittedWidth) / 2 - layout.bounds.minX * layout.scale;
   const offsetY = candidate.bounds.minY + (candidate.bounds.height - layout.fittedHeight) / 2 - layout.bounds.minY * layout.scale;
@@ -1339,7 +1283,7 @@ function computeTextPlacement(text, outlinePoints, basePlate, scale, options = {
     candidateIndex,
     candidateCount: candidates.length,
     placementRank: placementRank + 1,
-    placementCount: chosenOrientation.placements.length,
+    placementCount: placements.length,
     contours,
     lineBounds,
     normalizedText,
@@ -1356,7 +1300,6 @@ export function __debugTextPlacement(text, outlinePoints, basePlate, scale, opti
     text: placement.text,
     lines: [...placement.lines],
     lineBounds: placement.lineBounds.map(bounds => ({ ...bounds })),
-    rotation: placement.rotation,
     scale: placement.scale,
     candidateIndex: placement.candidateIndex,
     candidateCount: placement.candidateCount,
@@ -1388,39 +1331,35 @@ export function __debugAllPlacements(text, outlinePoints, basePlate, scale, opti
     originX: scaledBasePlate.minX,
     originY: scaledBasePlate.minY,
   };
-  const orientationResults = rankTextPlacements(normalizedText, font, candidates, options.textOrientationMode, clearanceContext);
+  const placements = rankTextPlacements(normalizedText, font, candidates, clearanceContext);
 
-  return orientationResults.map(({ rotation, placements, topScore }) => ({
-    rotation,
-    topScore,
-    placements: placements.map(({ candidateIndex, layout, score, candidate }) => {
-      const textHeight = layout.averageLineHeight * layout.fittedScale;
-      const utilization = Math.min(1, (layout.fittedWidth * layout.fittedHeight) / Math.max(candidate.bounds.width * candidate.bounds.height, Number.EPSILON));
-      const lineBalance = layout.maxLineWidth > 0 ? layout.minLineWidth / layout.maxLineWidth : 1;
-      return {
-        candidateIndex,
-        lines: layout.lines,
-        lineCount: layout.lineCount,
-        score,
-        textHeight,
-        utilization,
-        lineBalance,
-        averageLineHeight: layout.averageLineHeight,
-        fittedScale: layout.fittedScale,
-        fittedWidth: layout.fittedWidth,
-        fittedHeight: layout.fittedHeight,
-        candidateArea: candidate.area,
-        candidateWidth: candidate.bounds.width,
-        candidateHeight: candidate.bounds.height,
-        fractionOutside: candidate.fractionOutside,
-        normalizedTrackClearance: candidate.normalizedTrackClearance,
-        centreDistance: candidate.centreDistance,
-        sizeWindowMultiplier: computeSizeWindowMultiplier(textHeight),
-        lineCountMultiplier: computeLineCountMultiplier(layout.lineCount),
-        textClearanceMultiplier: computeTextClearanceMultiplier(candidate.bounds, layout, clearanceContext),
-      };
-    }),
-  }));
+  return placements.map(({ candidateIndex, layout, score, candidate }) => {
+    const textHeight = layout.averageLineHeight * layout.fittedScale;
+    const utilization = Math.min(1, (layout.fittedWidth * layout.fittedHeight) / Math.max(candidate.bounds.width * candidate.bounds.height, Number.EPSILON));
+    const lineBalance = layout.maxLineWidth > 0 ? layout.minLineWidth / layout.maxLineWidth : 1;
+    return {
+      candidateIndex,
+      lines: layout.lines,
+      lineCount: layout.lineCount,
+      score,
+      textHeight,
+      utilization,
+      lineBalance,
+      averageLineHeight: layout.averageLineHeight,
+      fittedScale: layout.fittedScale,
+      fittedWidth: layout.fittedWidth,
+      fittedHeight: layout.fittedHeight,
+      candidateArea: candidate.area,
+      candidateWidth: candidate.bounds.width,
+      candidateHeight: candidate.bounds.height,
+      fractionOutside: candidate.fractionOutside,
+      normalizedTrackClearance: candidate.normalizedTrackClearance,
+      centreDistance: candidate.centreDistance,
+      sizeWindowMultiplier: computeSizeWindowMultiplier(textHeight),
+      lineCountMultiplier: computeLineCountMultiplier(layout.lineCount),
+      textClearanceMultiplier: computeTextClearanceMultiplier(candidate.bounds, layout, clearanceContext),
+    };
+  });
 }
 
 export function __debugPlacementCandidates(outlinePoints, basePlate, scale) {
@@ -1497,43 +1436,31 @@ export function computeRankedTextPlacements(text, outlinePoints, basePlate, scal
     originX: scaledBasePlate.minX,
     originY: scaledBasePlate.minY,
   };
-  const orientationResults = rankTextPlacements(
+  const placements = rankTextPlacements(
     normalizedText,
     font,
     candidates,
-    options.textOrientationMode,
     clearanceContext,
   );
-  if (!orientationResults.length) {
+  if (!placements.length) {
     return null;
   }
 
-  return { orientationResults, clearanceContext, candidates, scaledBasePlate };
+  return { placements, clearanceContext, candidates, scaledBasePlate };
 }
 
 export function buildTextMeshFromRankedPlacements(rankedResult, options = {}) {
-  if (!rankedResult?.orientationResults?.length) {
+  if (!rankedResult?.placements?.length) {
     return [];
   }
 
-  const { orientationResults } = rankedResult;
-
-  let chosenOrientation;
-  if (normalizeTextOrientationMode(options.textOrientationMode) === TEXT_ORIENTATION_FIXED) {
-    chosenOrientation = orientationResults.find(o => o.rotation === 0) ?? orientationResults[0];
-  } else {
-    chosenOrientation = orientationResults[0];
-  }
-
-  if (!chosenOrientation?.placements?.length) {
-    return [];
-  }
+  const { placements } = rankedResult;
 
   const placementRank = Math.min(
     normalizeTextPositionRank(options.textPositionRank) - 1,
-    chosenOrientation.placements.length - 1,
+    placements.length - 1,
   );
-  const selected = chosenOrientation.placements[placementRank];
+  const selected = placements[placementRank];
   const { candidate, layout } = selected;
   const offsetX = candidate.bounds.minX + (candidate.bounds.width - layout.fittedWidth) / 2 - layout.bounds.minX * layout.scale;
   const offsetY = candidate.bounds.minY + (candidate.bounds.height - layout.fittedHeight) / 2 - layout.bounds.minY * layout.scale;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -523,9 +523,7 @@ test('buildTrackModel auto orientation rotates the model for portrait tracks and
   const explicitModel = buildTrackModel({ outlinePoints, basePlate, trackName: 'IMOLA', primaryOrientationDeg: 0 });
 
   assert.equal(autoModel.primaryOrientationDeg, 'auto');
-  assert.equal(autoModel.textOrientationMode, 'fixed');
   assert.equal(explicitModel.primaryOrientationDeg, 0);
-  assert.equal(explicitModel.textOrientationMode, 'fixed');
   assert.ok(autoModel.textTriangleCount > 0);
   assert.ok(explicitModel.textTriangleCount > 0);
 

--- a/test/text3d.test.js
+++ b/test/text3d.test.js
@@ -5,7 +5,6 @@ import { BASE_THICKNESS_MM } from '../src/model.js';
 import { rotateOutlineByOrientation } from '../src/orientation.js';
 import {
   TEXT_HEIGHT_MM,
-  TEXT_ORIENTATION_FIXED,
   __debugTextPlacement,
   __debugTextFitModifiers,
   __debugCompareRankedTextPlacements,
@@ -99,17 +98,10 @@ function assertRenderedLineOrder(layout) {
 
   const centers = layout.lineBounds.map(boundsCenter);
   for (let index = 1; index < centers.length; index += 1) {
-    if (layout.rotation === 90) {
-      assert.ok(
-        centers[index - 1].x < centers[index].x,
-        `expected rotated line ${index} to render after line ${index - 1} along x, got ${centers[index - 1].x} and ${centers[index].x}`,
-      );
-    } else {
-      assert.ok(
-        centers[index - 1].y > centers[index].y,
-        `expected line ${index - 1} above line ${index}, got ${centers[index - 1].y} and ${centers[index].y}`,
-      );
-    }
+    assert.ok(
+      centers[index - 1].y > centers[index].y,
+      `expected line ${index - 1} above line ${index}, got ${centers[index - 1].y} and ${centers[index].y}`,
+    );
   }
 }
 
@@ -533,50 +525,19 @@ test('multiline line stacking preserves top-to-bottom order without rotation', (
     outline,
     { minX: 0, minY: 0, maxX: 300, maxY: 200, width: 300, height: 200 },
     1,
-    { font: createMockFont(), baseThickness: BASE_THICKNESS_MM, textOrientationMode: TEXT_ORIENTATION_FIXED },
-  );
-
-  assert.ok(layout);
-  assert.ok(layout.lines.length > 1, `expected multiline, got: ${JSON.stringify(layout.lines)}`);
-  assert.equal(layout.rotation, 0);
-  assert.equal(collapseWhitespace(layout.text), 'Autodromo Nazionale di Monza');
-  assertRenderedLineOrder(layout);
-});
-
-test('multiline line stacking preserves top-to-bottom order after 90 degree rotation', () => {
-  // A small near-square infield (30mm wide × 70mm tall) forces multiline at rotation=90:
-  // single-line rotated 90° is too short to score, while 3-line rotated 90° fits within
-  // the preferred size range. Auto orientation picks rotation=90 since rotation=0 scores
-  // near zero in such a narrow space.
-  const outline = centeredHoleOutline({
-    width: 200,
-    height: 200,
-    holeMinX: 85,
-    holeMaxX: 115,
-    holeMinY: 65,
-    holeMaxY: 135,
-  });
-
-  const layout = __debugTextPlacement(
-    'Autodromo Nazionale di Monza',
-    outline,
-    { minX: 0, minY: 0, maxX: 200, maxY: 200, width: 200, height: 200 },
-    1,
     { font: createMockFont(), baseThickness: BASE_THICKNESS_MM },
   );
 
   assert.ok(layout);
   assert.ok(layout.lines.length > 1, `expected multiline, got: ${JSON.stringify(layout.lines)}`);
-  assert.equal(layout.rotation, 90);
   assert.equal(collapseWhitespace(layout.text), 'Autodromo Nazionale di Monza');
   assertRenderedLineOrder(layout);
 });
 
-test('placement rank and orientation mode do not alter word order', () => {
+test('placement rank does not alter word order', () => {
   const outline = rankedHoleOutline();
   const basePlate = { minX: 0, maxX: 2400, minY: 0, maxY: 1800, width: 2400, height: 1800 };
   const rankText = 'Las Vegas Strip Circuit';
-  const orientationText = 'Imola Circuit';
   const font = createMockFont();
 
   const firstRank = __debugTextPlacement(rankText, outline, basePlate, 1, {
@@ -589,75 +550,15 @@ test('placement rank and orientation mode do not alter word order', () => {
     baseThickness: BASE_THICKNESS_MM,
     textPositionRank: 2,
   });
-  const autoOrientation = __debugTextPlacement(orientationText, centeredHoleOutline({
-    width: 300,
-    height: 2000,
-    holeMinX: 135,
-    holeMaxX: 165,
-    holeMinY: 200,
-    holeMaxY: 1800,
-  }), { minX: 0, maxX: 300, minY: 0, maxY: 2000, width: 300, height: 2000 }, 1, {
-    font,
-    baseThickness: BASE_THICKNESS_MM,
-  });
-  const fixedOrientation = __debugTextPlacement(orientationText, rankedHoleOutline(), basePlate, 1, {
-    font,
-    baseThickness: BASE_THICKNESS_MM,
-    textOrientationMode: TEXT_ORIENTATION_FIXED,
-  });
 
   for (const [layout, expectedText] of [
     [firstRank, rankText],
     [secondRank, rankText],
-    [autoOrientation, orientationText],
-    [fixedOrientation, orientationText],
   ]) {
     assert.ok(layout);
     assert.equal(collapseWhitespace(layout.text), expectedText);
     assert.equal(layout.text, layout.lines.join('\n'));
   }
-});
-
-test('buildTextMesh auto mode can choose 90 degree text orientation when fixed mode cannot fit', () => {
-  const width = 300;
-  const height = 2000;
-  const outline = centeredHoleOutline({
-    width,
-    height,
-    holeMinX: width * 0.48,
-    holeMaxX: width * 0.52,
-    holeMinY: 200,
-    holeMaxY: 1800,
-  });
-
-  const layout = __debugTextPlacement(
-    'DAYTONA ROAD COURSE',
-    outline,
-    { minX: 0, maxX: width, minY: 0, maxY: height, width, height },
-    1,
-    { font: createMockFont(), baseThickness: BASE_THICKNESS_MM },
-  );
-
-  assert.ok(layout);
-  assert.equal(layout.rotation, 90);
-
-  const autoTriangles = buildTextMesh(
-    'DAYTONA ROAD COURSE',
-    outline,
-    { minX: 0, maxX: width, minY: 0, maxY: height, width, height },
-    1,
-    { font: createMockFont(), baseThickness: BASE_THICKNESS_MM },
-  );
-  const fixedTriangles = buildTextMesh(
-    'DAYTONA ROAD COURSE',
-    outline,
-    { minX: 0, maxX: width, minY: 0, maxY: height, width, height },
-    1,
-    { font: createMockFont(), baseThickness: BASE_THICKNESS_MM, textOrientationMode: TEXT_ORIENTATION_FIXED },
-  );
-
-  assert.ok(autoTriangles.length > 0);
-  assert.deepEqual(fixedTriangles, []);
 });
 
 test('buildTextMesh recomputes placement in the rotated search space', () => {
@@ -726,15 +627,13 @@ test('buildTextMesh uses the selected ranked placement candidate', () => {
   assert.ok(second);
   assert.ok(third);
   assert.ok(
-    first.rotation !== second.rotation
-      || first.scale !== second.scale
+    first.scale !== second.scale
       || first.candidateIndex !== second.candidateIndex
       || first.lines.join('\n') !== second.lines.join('\n'),
     'expected rank 1 and rank 2 to select different placements',
   );
   assert.ok(
-    first.rotation !== third.rotation
-      || first.scale !== third.scale
+    first.scale !== third.scale
       || first.candidateIndex !== third.candidateIndex
       || first.lines.join('\n') !== third.lines.join('\n'),
     'expected rank 1 and rank 3 to select different placements',
@@ -824,7 +723,7 @@ test('debug placements expose textClearanceMultiplier in the expected range', ()
   });
 
   assert.ok(orientations);
-  const allPlacements = orientations.flatMap(o => o.placements);
+  const allPlacements = orientations;
   assert.ok(allPlacements.length > 0, 'expected at least one placement');
 
   for (const placement of allPlacements) {
@@ -860,8 +759,8 @@ test('text clearance multiplier is higher when text has more breathing room from
   assert.ok(shortText);
   assert.ok(longText);
 
-  const shortBest = shortText[0]?.placements[0];
-  const longBest = longText[0]?.placements[0];
+  const shortBest = shortText[0];
+  const longBest = longText[0];
 
   assert.ok(shortBest, 'expected a placement for short text');
   assert.ok(longBest, 'expected a placement for long text');
@@ -890,7 +789,7 @@ test('text clearance multiplier is above the floor when text is far from the tra
   });
 
   assert.ok(orientations);
-  const best = orientations[0]?.placements[0];
+  const best = orientations[0];
   assert.ok(best, 'expected a placement');
   assert.ok(
     best.textClearanceMultiplier > 0.96,


### PR DESCRIPTION
## Summary
- Removed dead per-text rotation code (`getTextRotationCandidates`, `normalizeTextOrientationMode`, `rotateContours90`, `rotateBounds90`) from `text3d.js`
- Removed `TEXT_ORIENTATION_AUTO`/`TEXT_ORIENTATION_FIXED` exports and `textOrientationMode` parameter threading through all public APIs in `text3d.js` and `model.js`
- Simplified `rankTextPlacements` to always use rotation=0 (no more orientation candidate loop), and flattened the `computeRankedTextPlacements` / `buildTextMeshFromRankedPlacements` data structures accordingly
- Updated tests and `docs/text-placement-spec.md` to reflect the simplified API

Net result: **-189 lines** across 5 files, with all 148 tests passing.

Closes #43

## Test plan
- [x] `npm test` passes (148 tests, 0 failures)
- [x] No dangling references to removed functions or exports
- [x] Verified `__debugAllPlacements` tests updated to match new flat array return shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)