### PR TITLE
feat: add tag filtering and color coding to debug layout view

### DIFF
--- a/debug.html
+++ b/debug.html
@@ -241,6 +241,98 @@
         min-height: 1.2em;
       }
 
+      #filter-panel {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      #filter-groups {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .filter-group {
+        border-bottom: 1px solid var(--border);
+        padding: 6px 0;
+      }
+
+      .filter-group:last-child {
+        border-bottom: none;
+      }
+
+      .filter-group-header {
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 0.85rem;
+        color: var(--text-muted);
+        padding: 2px 0;
+        user-select: none;
+      }
+
+      .filter-chevron {
+        font-size: 0.65rem;
+        width: 12px;
+        text-align: center;
+        flex-shrink: 0;
+      }
+
+      .filter-key-name {
+        flex: 1;
+        font-weight: 600;
+      }
+
+      .filter-group-header .filter-count {
+        color: var(--text-soft);
+        font-size: 0.75rem;
+      }
+
+      .filter-toggle-all {
+        background: none;
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        color: var(--text-soft);
+        cursor: pointer;
+        font-size: 0.7rem;
+        padding: 1px 6px;
+        line-height: 1.4;
+      }
+
+      .filter-toggle-all:hover {
+        color: var(--text);
+        border-color: var(--border-strong);
+      }
+
+      .filter-group-body {
+        padding: 4px 0 2px 18px;
+      }
+
+      .filter-group.collapsed .filter-group-body {
+        display: none;
+      }
+
+      .filter-checkbox {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 0.82rem;
+        color: var(--text-muted);
+        padding: 1px 0;
+        cursor: pointer;
+      }
+
+      .filter-checkbox input[type="checkbox"] {
+        accent-color: var(--accent);
+        margin: 0;
+      }
+
+      .filter-count {
+        color: var(--text-soft);
+        font-size: 0.75rem;
+      }
+
       .legend {
         display: flex;
         flex-wrap: wrap;
@@ -286,8 +378,15 @@
 
         <div id="status-bar"></div>
 
+        <div id="filter-panel">
+          <h2>Tag Filters</h2>
+          <div id="filter-groups"></div>
+        </div>
+
         <div class="legend">
           <div class="legend-item"><span class="legend-swatch" style="background:#888"></span> OSM way</div>
+          <div class="legend-item"><span class="legend-swatch" style="background:#ffaa00"></span> highway=raceway</div>
+          <div class="legend-item"><span class="legend-swatch" style="background:#44ddaa"></span> Relation member</div>
           <div class="legend-item"><span class="legend-swatch" style="background:#ff234f"></span> Track layout</div>
           <div class="legend-item"><span class="legend-swatch" style="background:#00ccff"></span> Selected way</div>
         </div>

--- a/src/debug/entry.ts
+++ b/src/debug/entry.ts
@@ -46,6 +46,8 @@ const UNTAGGED = '__untagged__';
 
 // Tags always shown in filter panel (build-step relevant)
 const PRIORITY_TAG_KEYS = ['highway', 'rel:type', 'rel:route', 'sport'];
+// Tags that start expanded in the filter panel
+const DEFAULT_EXPANDED_KEYS = new Set(['highway', 'rel:type']);
 // Tags excluded from auto-discovery (noisy/uninteresting)
 const EXCLUDED_TAG_KEYS = new Set([
   'source', 'created_by', 'note', 'fixme', 'attribution', 'import',
@@ -193,6 +195,7 @@ async function selectTrack(track: SearchResult): Promise<void> {
 
     drawOsmWays(ways);
     rebuildTagCensus();
+    initCollapsedGroups();
     renderFilterPanel();
     updateFilteredStatus();
   } catch (err) {
@@ -253,6 +256,7 @@ function clearMap(): void {
   wayRelationMap.clear();
   tagCensus = new Map();
   activeFilters.clear();
+  collapsedGroups.clear();
   filterGroups.innerHTML = '';
   renderWayList();
 }
@@ -526,22 +530,21 @@ function updateFilteredStatus(shownCount?: number, totalCount?: number): void {
 
 // --- Filter panel rendering ---
 
+function initCollapsedGroups(): void {
+  const keys = getFilterableTagKeys();
+  for (const key of keys) {
+    if (!DEFAULT_EXPANDED_KEYS.has(key)) {
+      collapsedGroups.add(key);
+    }
+  }
+}
+
 function renderFilterPanel(): void {
   const keys = getFilterableTagKeys();
   if (keys.length === 0) {
     filterGroups.innerHTML = '';
     return;
   }
-
-  // Initialize collapsed state: only highway and rel:type start expanded
-  for (const key of keys) {
-    if (!PRIORITY_TAG_KEYS.slice(0, 2).includes(key) && !collapsedGroups.has(key)) {
-      collapsedGroups.add(key);
-    }
-  }
-  // Make sure highway and rel:type are NOT collapsed (remove if present)
-  collapsedGroups.delete('highway');
-  collapsedGroups.delete('rel:type');
 
   const html = keys.map(key => {
     const values = tagCensus.get(key)!;

--- a/src/debug/entry.ts
+++ b/src/debug/entry.ts
@@ -3,7 +3,7 @@ import type { TrackSearchEntry, SearchResult } from '../types/search.js';
 import type { Layout } from '../types/geometry.js';
 import { searchLocalTrackIndex } from '../search/scoring.js';
 import { getTrackGeometry } from '../search/geometry-index.js';
-import { parseOsmXmlElements, buildOsmApiMapUrl, type ParsedOsmWay } from '../geometry/osm-xml-parser.js';
+import { parseOsmXmlElements, buildOsmApiMapUrl, type ParsedOsmWay, type ParsedOsmElements } from '../geometry/osm-xml-parser.js';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // Leaflet is loaded via CDN in debug.html — use ambient global
@@ -30,7 +30,33 @@ const selectedWayIds = new Set<number>();
 const wayDataById = new Map<number, ParsedOsmWay>();
 const wayLayerById = new Map<number, any>();
 
+// Relation data and way-relation membership
+interface WayRelationInfo { relationId: number; tags: Record<string, string>; role: string }
+const wayRelationMap = new Map<number, WayRelationInfo[]>();
+
+// Tag filtering state
+// Map<tagKey, Map<tagValue, count>> — census of all tag values across loaded ways
+let tagCensus = new Map<string, Map<string, number>>();
+// Map<tagKey, Set<uncheckedValues>> — only stores unchecked values; absent key = no filter
+const activeFilters = new Map<string, Set<string>>();
+// Collapsed state for filter groups
+const collapsedGroups = new Set<string>();
+
+const UNTAGGED = '__untagged__';
+
+// Tags always shown in filter panel (build-step relevant)
+const PRIORITY_TAG_KEYS = ['highway', 'rel:type', 'rel:route', 'sport'];
+// Tags excluded from auto-discovery (noisy/uninteresting)
+const EXCLUDED_TAG_KEYS = new Set([
+  'source', 'created_by', 'note', 'fixme', 'attribution', 'import',
+  'source:name', 'source:ref', 'source:date', 'source:geometry',
+  'wikidata', 'wikipedia', 'is_in', 'addr:city', 'addr:country',
+  'addr:postcode', 'addr:state', 'addr:street', 'addr:housenumber',
+]);
+
 const WAY_COLOR_DEFAULT = '#888';
+const WAY_COLOR_RACEWAY = '#ffaa00';
+const WAY_COLOR_RELATION = '#44ddaa';
 const WAY_COLOR_SELECTED = '#00ccff';
 const LAYOUT_COLOR = '#ff234f';
 
@@ -42,6 +68,7 @@ const trackInfo = document.getElementById('track-info') as HTMLDivElement;
 const wayList = document.getElementById('way-list') as HTMLDivElement;
 const copyBtn = document.getElementById('copy-btn') as HTMLButtonElement;
 const toggleLayouts = document.getElementById('toggle-layouts') as HTMLInputElement;
+const filterGroups = document.getElementById('filter-groups') as HTMLDivElement;
 const statusBar = document.getElementById('status-bar') as HTMLDivElement;
 
 // --- Map init ---
@@ -144,13 +171,30 @@ async function selectTrack(track: SearchResult): Promise<void> {
   // Draw layouts
   drawLayouts(geo.layouts);
 
-  // Fetch OSM ways via the same API the build script uses, with adaptive margin shrinking
+  // Fetch OSM ways + relations via the same API the build script uses, with adaptive margin shrinking
   setStatus('Fetching OSM data...');
   try {
-    const ways = await fetchOsmApiWaysAdaptive(center.lat, center.lon, controller.signal);
+    const { ways, relations } = await fetchOsmApiWaysAdaptive(center.lat, center.lon, controller.signal);
     if (controller.signal.aborted) {return;}
-    setStatus(`${ways.length} ways loaded.`);
+
+    // Build way-relation mapping
+    for (const rel of relations) {
+      for (const member of rel.members) {
+        if (member.type === 'way') {
+          let entries = wayRelationMap.get(member.ref);
+          if (!entries) {
+            entries = [];
+            wayRelationMap.set(member.ref, entries);
+          }
+          entries.push({ relationId: rel.id, tags: rel.tags, role: member.role });
+        }
+      }
+    }
+
     drawOsmWays(ways);
+    rebuildTagCensus();
+    renderFilterPanel();
+    updateFilteredStatus();
   } catch (err) {
     if (controller.signal.aborted) {return;}
     setStatus(`OSM API error: ${(err as Error).message}`);
@@ -164,7 +208,7 @@ const DEFAULT_MARGIN = 0.02;
 const MIN_MARGIN = 0.001;
 const MAX_ATTEMPTS = 6;
 
-async function fetchOsmApiWays(lat: number, lon: number, margin: number, signal?: AbortSignal): Promise<ParsedOsmWay[]> {
+async function fetchOsmApiWays(lat: number, lon: number, margin: number, signal?: AbortSignal): Promise<ParsedOsmElements> {
   const url = buildOsmApiMapUrl(lat, lon, margin);
   const response = await fetch(url, signal ? { signal } : {});
 
@@ -176,11 +220,10 @@ async function fetchOsmApiWays(lat: number, lon: number, margin: number, signal?
   }
 
   const xml = await response.text();
-  const { ways } = parseOsmXmlElements(xml, { includeRelations: false });
-  return ways;
+  return parseOsmXmlElements(xml, { includeRelations: true });
 }
 
-async function fetchOsmApiWaysAdaptive(lat: number, lon: number, signal?: AbortSignal): Promise<ParsedOsmWay[]> {
+async function fetchOsmApiWaysAdaptive(lat: number, lon: number, signal?: AbortSignal): Promise<ParsedOsmElements> {
   let margin = DEFAULT_MARGIN;
 
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
@@ -207,6 +250,10 @@ function clearMap(): void {
   selectedWayIds.clear();
   wayDataById.clear();
   wayLayerById.clear();
+  wayRelationMap.clear();
+  tagCensus = new Map();
+  activeFilters.clear();
+  filterGroups.innerHTML = '';
   renderWayList();
 }
 
@@ -223,21 +270,58 @@ function drawLayouts(layouts: Layout[]): void {
   }
 }
 
+function getWayColor(way: ParsedOsmWay): string {
+  if (String(way.tags['highway'] ?? '').toLowerCase() === 'raceway') {return WAY_COLOR_RACEWAY;}
+  if (wayRelationMap.has(way.id)) {return WAY_COLOR_RELATION;}
+  return WAY_COLOR_DEFAULT;
+}
+
+function getEffectiveTags(way: ParsedOsmWay): Record<string, string> {
+  const tags: Record<string, string> = { ...way.tags };
+  const rels = wayRelationMap.get(way.id);
+  if (rels) {
+    // Collect unique relation-level tag values
+    const relTypes = new Set<string>();
+    const relRoutes = new Set<string>();
+    const relSports = new Set<string>();
+    for (const r of rels) {
+      if (r.tags['type']) {relTypes.add(r.tags['type']);}
+      if (r.tags['route']) {relRoutes.add(r.tags['route']);}
+      if (r.tags['sport']) {relSports.add(r.tags['sport']);}
+    }
+    if (relTypes.size > 0) {tags['rel:type'] = [...relTypes].join(', ');}
+    if (relRoutes.size > 0) {tags['rel:route'] = [...relRoutes].join(', ');}
+    if (relSports.size > 0) {tags['rel:sport'] = [...relSports].join(', ');}
+  }
+  return tags;
+}
+
 function drawOsmWays(ways: ParsedOsmWay[]): void {
   for (const way of ways) {
     wayDataById.set(way.id, way);
     const latlngs = way.geometry.map((n) => [n.lat, n.lon] as [number, number]);
+    const baseColor = getWayColor(way);
     const polyline = L.polyline(latlngs, {
-      color: WAY_COLOR_DEFAULT,
-      weight: 3,
-      opacity: 0.6,
+      color: baseColor,
+      weight: baseColor === WAY_COLOR_DEFAULT ? 3 : 4,
+      opacity: baseColor === WAY_COLOR_DEFAULT ? 0.6 : 0.85,
     }).addTo(map);
 
+    // Build tooltip with key tags
     const name = way.tags['name'] || way.tags['ref'] || `way/${way.id}`;
+    const tagLines = Object.entries(way.tags)
+      .filter(([k]) => k !== 'name' && k !== 'ref')
+      .slice(0, 6)
+      .map(([k, v]) => `${escapeHtml(k)}=${escapeHtml(v)}`)
+      .join('<br/>');
+
+    const rels = wayRelationMap.get(way.id) ?? [];
+    const relationInfo = rels
+      .map(r => `relation/${r.relationId} (${escapeHtml(r.tags['name'] ?? r.tags['type'] ?? '?')}${r.role ? `, role=${escapeHtml(r.role)}` : ''})`)
+      .join('<br/>');
+
     polyline.bindTooltip(
-      `<strong>${escapeHtml(name)}</strong><br/>` +
-      `ID: ${way.id}<br/>` +
-      `${way.tags['highway'] ? `highway=${escapeHtml(way.tags['highway'])}` : ''}`,
+      `<strong>${escapeHtml(name)}</strong><br/>ID: ${way.id}<br/>${tagLines ? `${tagLines}<br/>` : ''}${relationInfo ? `<em>Relations:</em><br/>${relationInfo}` : ''}`,
       { sticky: true },
     );
 
@@ -249,10 +333,27 @@ function drawOsmWays(ways: ParsedOsmWay[]): void {
 
 // --- Way selection ---
 
+function restoreWayStyle(wayId: number): void {
+  const way = wayDataById.get(wayId);
+  if (!way) {return;}
+  const color = getWayColor(way);
+  wayLayerById.get(wayId)?.setStyle({
+    color,
+    weight: color === WAY_COLOR_DEFAULT ? 3 : 4,
+    opacity: color === WAY_COLOR_DEFAULT ? 0.6 : 0.85,
+  });
+}
+
 function toggleWaySelection(wayId: number): void {
   if (selectedWayIds.has(wayId)) {
     selectedWayIds.delete(wayId);
-    wayLayerById.get(wayId)?.setStyle({ color: WAY_COLOR_DEFAULT, weight: 3, opacity: 0.6 });
+    restoreWayStyle(wayId);
+    // Hide if filtered out
+    const way = wayDataById.get(wayId);
+    if (way && !passesFilters(way)) {
+      const layer = wayLayerById.get(wayId);
+      if (layer && map.hasLayer(layer)) {map.removeLayer(layer);}
+    }
   } else {
     selectedWayIds.add(wayId);
     wayLayerById.get(wayId)?.setStyle({ color: WAY_COLOR_SELECTED, weight: 5, opacity: 1 });
@@ -262,7 +363,12 @@ function toggleWaySelection(wayId: number): void {
 
 function deselectWay(wayId: number): void {
   selectedWayIds.delete(wayId);
-  wayLayerById.get(wayId)?.setStyle({ color: WAY_COLOR_DEFAULT, weight: 3, opacity: 0.6 });
+  restoreWayStyle(wayId);
+  const way = wayDataById.get(wayId);
+  if (way && !passesFilters(way)) {
+    const layer = wayLayerById.get(wayId);
+    if (layer && map.hasLayer(layer)) {map.removeLayer(layer);}
+  }
   renderWayList();
 }
 
@@ -315,6 +421,231 @@ toggleLayouts.addEventListener('change', () => {
     }
   }
 });
+
+// --- Tag census and filtering ---
+
+function rebuildTagCensus(): void {
+  tagCensus = new Map();
+
+  for (const [, way] of wayDataById) {
+    const effective = getEffectiveTags(way);
+    // Count each tag key's values
+    for (const [key, value] of Object.entries(effective)) {
+      if (EXCLUDED_TAG_KEYS.has(key)) {continue;}
+      let valueCounts = tagCensus.get(key);
+      if (!valueCounts) {
+        valueCounts = new Map();
+        tagCensus.set(key, valueCounts);
+      }
+      // For multi-value rel: tags (comma-separated), count each value separately
+      const values = key.startsWith('rel:') ? value.split(', ') : [value];
+      for (const v of values) {
+        valueCounts.set(v, (valueCounts.get(v) ?? 0) + 1);
+      }
+    }
+
+    // Count untagged for priority keys
+    for (const pk of PRIORITY_TAG_KEYS) {
+      if (!(pk in effective)) {
+        let valueCounts = tagCensus.get(pk);
+        if (!valueCounts) {
+          valueCounts = new Map();
+          tagCensus.set(pk, valueCounts);
+        }
+        valueCounts.set(UNTAGGED, (valueCounts.get(UNTAGGED) ?? 0) + 1);
+      }
+    }
+  }
+}
+
+function getFilterableTagKeys(): string[] {
+  const keys: string[] = [];
+  // Priority tags first (always shown if they have any values)
+  for (const pk of PRIORITY_TAG_KEYS) {
+    const values = tagCensus.get(pk);
+    if (values && values.size > 0) {keys.push(pk);}
+  }
+  // Auto-discovered tags: present on 3+ ways with 2+ distinct values
+  for (const [key, values] of tagCensus) {
+    if (PRIORITY_TAG_KEYS.includes(key)) {continue;}
+    if (EXCLUDED_TAG_KEYS.has(key)) {continue;}
+    const totalCount = [...values.values()].reduce((a, b) => a + b, 0);
+    if (totalCount >= 3 && values.size >= 2) {keys.push(key);}
+  }
+  return keys;
+}
+
+function passesFilters(way: ParsedOsmWay): boolean {
+  if (activeFilters.size === 0) {return true;}
+  const effective = getEffectiveTags(way);
+
+  for (const [key, uncheckedValues] of activeFilters) {
+    if (uncheckedValues.size === 0) {continue;}
+    const rawValue = effective[key];
+
+    if (rawValue === undefined) {
+      // Way is untagged for this key — check if untagged is unchecked
+      if (uncheckedValues.has(UNTAGGED)) {return false;}
+    } else {
+      // For rel: tags, check if ANY value passes
+      const values = key.startsWith('rel:') ? rawValue.split(', ') : [rawValue];
+      const allUnchecked = values.every(v => uncheckedValues.has(v));
+      if (allUnchecked) {return false;}
+    }
+  }
+  return true;
+}
+
+function applyFilters(): void {
+  let shown = 0;
+  let total = 0;
+  for (const [wayId, layer] of wayLayerById) {
+    total++;
+    const way = wayDataById.get(wayId)!;
+    const visible = selectedWayIds.has(wayId) || passesFilters(way);
+    if (visible) {
+      shown++;
+      if (!map.hasLayer(layer)) {layer.addTo(map);}
+    } else if (map.hasLayer(layer)) {
+      map.removeLayer(layer);
+    }
+  }
+  updateFilteredStatus(shown, total);
+}
+
+function updateFilteredStatus(shownCount?: number, totalCount?: number): void {
+  const total = totalCount ?? wayDataById.size;
+  const shown = shownCount ?? total;
+  if (total === 0) {return;}
+  if (shown === total) {
+    setStatus(`${total} ways loaded.`);
+  } else {
+    setStatus(`Showing ${shown} of ${total} ways.`);
+  }
+}
+
+// --- Filter panel rendering ---
+
+function renderFilterPanel(): void {
+  const keys = getFilterableTagKeys();
+  if (keys.length === 0) {
+    filterGroups.innerHTML = '';
+    return;
+  }
+
+  // Initialize collapsed state: only highway and rel:type start expanded
+  for (const key of keys) {
+    if (!PRIORITY_TAG_KEYS.slice(0, 2).includes(key) && !collapsedGroups.has(key)) {
+      collapsedGroups.add(key);
+    }
+  }
+  // Make sure highway and rel:type are NOT collapsed (remove if present)
+  collapsedGroups.delete('highway');
+  collapsedGroups.delete('rel:type');
+
+  const html = keys.map(key => {
+    const values = tagCensus.get(key)!;
+    const collapsed = collapsedGroups.has(key);
+    const unchecked = activeFilters.get(key);
+
+    // Sort values: UNTAGGED last, then by count descending
+    const sorted = [...values.entries()].sort((a, b) => {
+      if (a[0] === UNTAGGED) {return 1;}
+      if (b[0] === UNTAGGED) {return -1;}
+      return b[1] - a[1];
+    });
+
+    const allChecked = !unchecked || unchecked.size === 0;
+    const noneChecked = unchecked && unchecked.size === sorted.length;
+
+    const checkboxes = sorted.map(([value, count]) => {
+      const checked = !unchecked?.has(value);
+      const displayValue = value === UNTAGGED ? '(untagged)' : escapeHtml(value);
+      return `<label class="filter-checkbox">
+        <input type="checkbox" data-tag-key="${escapeHtml(key)}" data-tag-value="${escapeHtml(value)}" ${checked ? 'checked' : ''} />
+        <span>${displayValue}</span>
+        <span class="filter-count">(${count})</span>
+      </label>`;
+    }).join('');
+
+    return `<div class="filter-group ${collapsed ? 'collapsed' : ''}" data-key="${escapeHtml(key)}">
+      <div class="filter-group-header" data-key="${escapeHtml(key)}">
+        <span class="filter-chevron">${collapsed ? '\u25b6' : '\u25bc'}</span>
+        <span class="filter-key-name">${escapeHtml(key)}</span>
+        <span class="filter-count">(${sorted.length})</span>
+        <button class="filter-toggle-all" data-key="${escapeHtml(key)}" title="${allChecked ? 'Select none' : 'Select all'}">${noneChecked ? 'All' : allChecked ? 'None' : 'All'}</button>
+      </div>
+      <div class="filter-group-body">${checkboxes}</div>
+    </div>`;
+  }).join('');
+
+  filterGroups.innerHTML = html;
+
+  // Wire up events
+  for (const header of filterGroups.querySelectorAll('.filter-group-header')) {
+    header.addEventListener('click', (e) => {
+      if ((e.target as HTMLElement).closest('.filter-toggle-all')) {return;}
+      const key = (header as HTMLElement).getAttribute('data-key')!;
+      if (collapsedGroups.has(key)) {
+        collapsedGroups.delete(key);
+      } else {
+        collapsedGroups.add(key);
+      }
+      renderFilterPanel();
+    });
+  }
+
+  for (const btn of filterGroups.querySelectorAll('.filter-toggle-all')) {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const key = (btn as HTMLElement).getAttribute('data-key')!;
+      const values = tagCensus.get(key)!;
+      const unchecked = activeFilters.get(key);
+      const allChecked = !unchecked || unchecked.size === 0;
+
+      if (allChecked) {
+        // Uncheck all
+        activeFilters.set(key, new Set(values.keys()));
+      } else {
+        // Check all
+        activeFilters.delete(key);
+      }
+      renderFilterPanel();
+      applyFilters();
+    });
+  }
+
+  for (const checkbox of filterGroups.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')) {
+    checkbox.addEventListener('change', () => {
+      const key = checkbox.getAttribute('data-tag-key')!;
+      const value = checkbox.getAttribute('data-tag-value')!;
+
+      let unchecked = activeFilters.get(key);
+      if (!unchecked) {
+        unchecked = new Set();
+        activeFilters.set(key, unchecked);
+      }
+
+      if (checkbox.checked) {
+        unchecked.delete(value);
+        if (unchecked.size === 0) {activeFilters.delete(key);}
+      } else {
+        unchecked.add(value);
+      }
+      applyFilters();
+      // Update toggle-all button text
+      const group = checkbox.closest('.filter-group');
+      if (group) {
+        const toggleBtn = group.querySelector('.filter-toggle-all');
+        if (toggleBtn) {
+          const uc = activeFilters.get(key);
+          toggleBtn.textContent = (!uc || uc.size === 0) ? 'None' : 'All';
+          toggleBtn.setAttribute('title', (!uc || uc.size === 0) ? 'Select none' : 'Select all');
+        }
+      }
+    });
+  }
+}
 
 // --- Status ---
 


### PR DESCRIPTION
## Summary
- Parse OSM relations alongside ways and build a way-relation mapping, surfacing build-step-relevant tags (`highway`, `rel:type`, `rel:route`, `sport`) in a dynamic filter panel
- Color-code ways by relevance: gold for `highway=raceway`, teal for relation members, gray for others
- Add collapsible tag filter groups with checkboxes, counts, and All/None toggles — auto-discovers additional tags (e.g. `surface`, `lanes`) when present on 3+ ways
- Enhanced tooltips showing full tag details and parent relation info

## Test plan
- [ ] Open `debug.html`, search for a circuit (e.g. Silverstone)
- [ ] Verify ways are color-coded (gold for raceway, teal for relation members, gray for others)
- [ ] Verify filter panel shows tag groups with correct counts
- [ ] Toggle filter checkboxes — ways should appear/disappear on the map
- [ ] Status bar should show "Showing X of Y ways" when filtering
- [ ] Select a different circuit — filters should reset
- [ ] Verify selected ways remain visible when filtered out, and hide when deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)