### PR TITLE
Adjustable track width with auto/manual control

### DIFF
--- a/src/components/OptionsPanel.svelte
+++ b/src/components/OptionsPanel.svelte
@@ -12,6 +12,7 @@
   import { normalizePrimaryOrientationDeg } from '../model/orientation.js';
   import { normalizeTextPositionRank, DEFAULT_TEXT_POSITION_RANK } from '../text3d.js';
   import { rebuildModel, loadElevations, invalidatePlacementCache } from '../track-loader.js';
+  import { MIN_COASTER_TRACK_WIDTH_MM } from '../model/track-ribbon.js';
   import { get } from 'svelte/store';
   import { nodes } from '../stores/model.js';
   import LayoutPicker from './LayoutPicker.svelte';
@@ -95,7 +96,9 @@
     scheduleTrackWidthRebuild();
   }
 
-  const TRACK_WIDTH_MIN = 1;
+  // Slider floor matches the coaster auto-mode minimum so manual mode can never
+  // request a width thinner than auto mode would allow.
+  const TRACK_WIDTH_MIN = MIN_COASTER_TRACK_WIDTH_MM;
   const TRACK_WIDTH_MAX = 10;
 
   function trackWidthGradient(value: number, disabled: boolean): string {

--- a/src/components/OptionsPanel.svelte
+++ b/src/components/OptionsPanel.svelte
@@ -5,6 +5,8 @@
     coasterMode,
     coasterShape,
     coasterInlay,
+    trackWidthAuto,
+    trackWidthMm,
   } from '../stores/options.js';
   import { selectedTrack, layouts } from '../stores/track.js';
   import { normalizePrimaryOrientationDeg } from '../model/orientation.js';
@@ -69,6 +71,38 @@
     coasterInlay.set((e.currentTarget as HTMLSelectElement).value as 'flush' | 'raised');
     handleCoasterChange();
   }
+
+  let trackWidthRebuildTimer: ReturnType<typeof setTimeout> | undefined;
+  function scheduleTrackWidthRebuild(): void {
+    if (!get(layouts).length || !get(selectedTrack)) {
+      return;
+    }
+    clearTimeout(trackWidthRebuildTimer);
+    trackWidthRebuildTimer = setTimeout(() => {
+      invalidatePlacementCache();
+      void rebuildModel();
+    }, 150);
+  }
+
+  function handleTrackWidthAutoToggle(e: Event): void {
+    trackWidthAuto.set((e.currentTarget as HTMLInputElement).checked);
+    scheduleTrackWidthRebuild();
+  }
+
+  function handleTrackWidthInput(e: Event): void {
+    const value = Number((e.currentTarget as HTMLInputElement).value);
+    trackWidthMm.set(value);
+    scheduleTrackWidthRebuild();
+  }
+
+  const TRACK_WIDTH_MIN = 1;
+  const TRACK_WIDTH_MAX = 10;
+
+  function trackWidthGradient(value: number, disabled: boolean): string {
+    const progress = ((value - TRACK_WIDTH_MIN) / (TRACK_WIDTH_MAX - TRACK_WIDTH_MIN)) * 100;
+    const fill = disabled ? 'rgba(99, 108, 128, 0.45)' : 'var(--accent)';
+    return `linear-gradient(90deg, ${fill} 0%, ${fill} ${progress}%, rgba(99, 108, 128, 0.45) ${progress}%, rgba(99, 108, 128, 0.45) 100%)`;
+  }
 </script>
 
 <div class="options-inner" aria-label="Model options">
@@ -91,6 +125,33 @@
       <option value="3" selected={$textPositionRank === 3}>Alternate 2</option>
     </select>
     <button class="debug-btn" onclick={() => debugScreenVisible.set(true)}>Debug</button>
+  </div>
+  <div class="field-card controls-wrap track-width-card">
+    <div class="range-header">
+      <label for="track-width">Track width</label>
+      <output id="track-width-value" for="track-width">
+        {$trackWidthAuto ? 'Auto' : `${$trackWidthMm} mm`}
+      </output>
+    </div>
+    <input
+      id="track-width"
+      type="range"
+      min={TRACK_WIDTH_MIN}
+      max={TRACK_WIDTH_MAX}
+      step="0.5"
+      value={$trackWidthMm}
+      disabled={$trackWidthAuto}
+      style="background: {trackWidthGradient($trackWidthMm, $trackWidthAuto)}"
+      oninput={handleTrackWidthInput}
+    />
+    <label class="track-width-auto">
+      <input
+        type="checkbox"
+        checked={$trackWidthAuto}
+        onchange={handleTrackWidthAutoToggle}
+      />
+      <span>Auto</span>
+    </label>
   </div>
   <div class="field-card controls-wrap">
     <label class="coaster-toggle">

--- a/src/model/orientation.ts
+++ b/src/model/orientation.ts
@@ -4,6 +4,7 @@ import type { OutlinePoints, BasePlate } from '../types/model.js';
 import type { Point2D, ProjectedNode } from '../types/geometry.js';
 import type { RankedPlacements } from '../types/text.js';
 import { computeScale } from './base-plate.js';
+import { TRACK_WIDTH_METRES } from './track-ribbon.js';
 
 // ── Primitives (merged from src/orientation.js) ──────────────────────────────
 
@@ -113,6 +114,8 @@ export interface OrientTrackGeometryOptions {
   basePlate: BasePlate | null | undefined;
   projectedNodes?: ProjectedNode[] | null;
   orientationDeg?: number;
+  /** Ribbon width in metres for outline rebuild. Defaults to TRACK_WIDTH_METRES. */
+  widthMetres?: number;
 }
 
 export interface OrientedTrackGeometry {
@@ -127,13 +130,14 @@ export function orientTrackGeometry({
   basePlate,
   projectedNodes = null,
   orientationDeg = 0,
+  widthMetres = TRACK_WIDTH_METRES,
 }: OrientTrackGeometryOptions): OrientedTrackGeometry {
   const normalizedOrientationDeg = normalizeOrientationDeg(orientationDeg);
   const orientedProjectedNodes = projectedNodes?.length
     ? (rotatePointsByOrientation(projectedNodes, normalizedOrientationDeg) as ProjectedNode[])
     : null;
   const orientedOutlinePoints = orientedProjectedNodes?.length
-    ? buildTrackOutline(orientedProjectedNodes)
+    ? buildTrackOutline(orientedProjectedNodes, widthMetres)
     : rotateOutlineByOrientation(outlinePoints, normalizedOrientationDeg);
   const orientedBasePlate = rotateBasePlateByOrientation(basePlate, normalizedOrientationDeg)
     ?? buildBasePlate(orientedOutlinePoints);
@@ -174,12 +178,13 @@ export function selectAutoOrientation(
   projectedNodes: ProjectedNode[] | null | undefined,
   trackName: string | null | undefined,
   secondaryProjectedNodes: ProjectedNode[][] = [],
+  widthMetres: number = TRACK_WIDTH_METRES,
 ): AutoOrientationResult {
   if (__autoOrientCounter) { __autoOrientCounter.selectAutoOrientation++; }
   // Build an outline we can use for all candidates.
   // projectedNodes takes priority — same logic as orientTrackGeometry.
   const baseOutline = projectedNodes?.length
-    ? buildTrackOutline(projectedNodes)
+    ? buildTrackOutline(projectedNodes, widthMetres)
     : outlinePoints;
   const bp = basePlate ?? (baseOutline ? buildBasePlate(baseOutline) : null);
   if (!bp) { return { deg: 0, placements: null, geometry: null }; }
@@ -223,7 +228,7 @@ export function selectAutoOrientation(
       ? (rotatePointsByOrientation(projectedNodes, deg) as ProjectedNode[])
       : null;
     const rotatedOutline = rotatedProjectedNodes
-      ? buildTrackOutline(rotatedProjectedNodes)
+      ? buildTrackOutline(rotatedProjectedNodes, widthMetres)
       : rotateOutlineByOrientation(outlinePoints, deg);
 
     // In combined mode, rotate all secondary layouts and expand the base plate to fit all of them.
@@ -231,7 +236,7 @@ export function selectAutoOrientation(
       rotatePointsByOrientation(nodes, deg) as ProjectedNode[]
     );
     const rotatedSecondaryOutlines = rotatedSecondaryNodes.map(nodes =>
-      buildTrackOutline(nodes)
+      buildTrackOutline(nodes, widthMetres)
     );
 
     // Compute basePlate using the same logic as orientTrackGeometry:

--- a/src/model/track-model.ts
+++ b/src/model/track-model.ts
@@ -16,6 +16,7 @@ import {
   COASTER_INNER_MARGIN_MM,
   COASTER_POCKET_DEPTH_MM,
   BASE_CORNER_RADIUS_MM,
+  TARGET_MAX_SIZE_MM,
   buildBasePlateMesh,
   buildCoasterBasePlateMesh,
   computeScale,
@@ -130,6 +131,81 @@ export interface BuildTrackModelOptions {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
+const COASTER_TARGET_ENVELOPE_MM = COASTER_SIZE_MM - 2 * (COASTER_INNER_MARGIN_MM + BASE_CORNER_RADIUS_MM);
+/** Total margin (both sides per axis) added by buildBasePlate's default 50 m margin. */
+const BASE_PLATE_MARGIN_TOTAL_METRES = 100;
+
+/**
+ * Solves for the ribbon width (in metres) that — once buffered by `buildTrackOutline`
+ * and bounded by `buildBasePlate` — renders at exactly `targetMm` printed millimetres.
+ *
+ * Derivation:
+ *   basePlate.longest = bbox(line).longest + widthMetres + 2 * margin
+ *   scale = TARGET_MM / basePlate.longest
+ *   rendered_mm = widthMetres * scale = targetMm  (we want this)
+ *   ⇒ widthMetres = targetMm * (B + M) / (TARGET_MM - targetMm)
+ * where B = bbox(line) longest side, M = 2 * margin.
+ */
+function solveWidthMetresForTargetMm(
+  bboxLongestMetres: number,
+  targetEnvelopeMm: number,
+  targetMm: number,
+): number {
+  if (!Number.isFinite(targetMm) || targetMm <= 0 || targetMm >= targetEnvelopeMm) {
+    return TRACK_WIDTH_METRES;
+  }
+  return targetMm * (bboxLongestMetres + BASE_PLATE_MARGIN_TOTAL_METRES) / (targetEnvelopeMm - targetMm);
+}
+
+/**
+ * Computes the effective ribbon width (metres) to be applied during outline
+ * construction, accounting for auto/manual mode and coaster vs non-coaster.
+ * Solved upfront so auto-orientation scoring and per-orientation text placement
+ * use the same outline as the final render.
+ */
+function computeEffectiveTrackWidthMetres(
+  projectedNodes: ProjectedNode[] | null | undefined,
+  secondaryProjectedNodes: ProjectedNode[][],
+  coasterMode: boolean,
+  trackWidthAuto: boolean,
+  trackWidthMm: number,
+): number {
+  if (trackWidthAuto && !coasterMode) {
+    return TRACK_WIDTH_METRES;
+  }
+
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  const accumulate = (nodes: ProjectedNode[] | null | undefined): void => {
+    if (!nodes?.length) { return; }
+    for (const n of nodes) {
+      if (n.x < minX) { minX = n.x; }
+      if (n.x > maxX) { maxX = n.x; }
+      if (n.y < minY) { minY = n.y; }
+      if (n.y > maxY) { maxY = n.y; }
+    }
+  };
+  accumulate(projectedNodes);
+  for (const nodes of secondaryProjectedNodes) {
+    accumulate(nodes);
+  }
+  const B = Math.max(maxX - minX, maxY - minY);
+  if (!Number.isFinite(B) || B <= 0) {
+    return TRACK_WIDTH_METRES;
+  }
+
+  const targetEnvelopeMm = coasterMode ? COASTER_TARGET_ENVELOPE_MM : TARGET_MAX_SIZE_MM;
+  if (!trackWidthAuto) {
+    return solveWidthMetresForTargetMm(B, targetEnvelopeMm, trackWidthMm);
+  }
+  // coasterMode auto: ensure rendered width >= MIN_COASTER_TRACK_WIDTH_MM,
+  // otherwise fall back to the default.
+  const widthAtMin = solveWidthMetresForTargetMm(B, targetEnvelopeMm, MIN_COASTER_TRACK_WIDTH_MM);
+  return Math.max(TRACK_WIDTH_METRES, widthAtMin);
+}
+
 function translatePoint<T extends { x: number; y: number }>(p: T, dx: number, dy: number): T {
   return { ...p, x: p.x + dx, y: p.y + dy };
 }
@@ -190,6 +266,16 @@ export function buildTrackModel({
   }
   const cacheActive = placementCacheToken !== null;
 
+  // Solve for the ribbon width (in metres) upfront so auto-orientation scoring,
+  // per-orientation text placement, and the final render all use the same outline.
+  const effectiveTrackWidthMetres = computeEffectiveTrackWidthMetres(
+    projectedNodes,
+    secondaryProjectedNodes,
+    coasterMode,
+    trackWidthAuto,
+    trackWidthMm,
+  );
+
   let resolvedOrientationDeg: number;
   // When selectAutoOrientation runs, it already computes the winning orientation's
   // geometry (outline, basePlate, projected nodes, secondary outlines) and text placements.
@@ -205,6 +291,7 @@ export function buildTrackModel({
       // so we pre-populate the cache with all of them in one pass.
       const autoResult = selectAutoOrientation(
         outlinePoints, basePlate, projectedNodes, trackName, secondaryProjectedNodes,
+        effectiveTrackWidthMetres,
       );
       resolvedOrientationDeg = autoResult.deg;
       autoGeometry = autoResult.geometry;
@@ -249,11 +336,12 @@ export function buildTrackModel({
       basePlate,
       projectedNodes,
       orientationDeg: resolvedOrientationDeg,
+      widthMetres: effectiveTrackWidthMetres,
     });
     orientedSecondaries = secondaryProjectedNodes.map(nodes =>
       rotatePointsByOrientation(nodes, resolvedOrientationDeg) as ProjectedNode[]
     );
-    secondaryOutlines = orientedSecondaries.map(nodes => buildTrackOutline(nodes));
+    secondaryOutlines = orientedSecondaries.map(nodes => buildTrackOutline(nodes, effectiveTrackWidthMetres));
   }
 
   perfTimer?.step('geometry');
@@ -264,24 +352,20 @@ export function buildTrackModel({
     ? (buildCombinedBasePlate([orientedGeometry.outlinePoints, ...secondaryOutlines]) ?? orientedGeometry.basePlate)
     : orientedGeometry.basePlate;
 
-  // ── Geometry & ribbon width setup ──────────────────────────────────────────
-  // Coaster mode translates geometry so the track's bounding-box centre sits at
-  // (0, 0), aligning with the coaster mesh which is rendered centred on the
-  // origin. Non-coaster mode keeps geometry in its original frame.
+  // ── Geometry post-processing ───────────────────────────────────────────────
+  // Outlines from the orientation pass are already at effectiveTrackWidthMetres,
+  // so non-coaster mode just needs the rendering scale. Coaster mode additionally
+  // translates the geometry so the track's bounding-box centre sits at (0, 0)
+  // (aligning with the coaster mesh) and substitutes a synthetic 90 mm base plate.
   let workingOutline = orientedGeometry.outlinePoints;
   let workingProjected = orientedGeometry.projectedNodes;
   let workingSecondaryOutlines = secondaryOutlines;
   let workingSecondaries = orientedSecondaries;
   let scale: number;
-  let effectiveTrackWidthMetres = TRACK_WIDTH_METRES;
 
   if (coasterMode) {
-    const targetEnvelopeMm = COASTER_SIZE_MM - 2 * (COASTER_INNER_MARGIN_MM + BASE_CORNER_RADIUS_MM);
     const longestSide = Math.max(effectiveBasePlate.width, effectiveBasePlate.height);
-    scale = longestSide > 0 ? targetEnvelopeMm / longestSide : 1;
-    effectiveTrackWidthMetres = trackWidthAuto
-      ? Math.max(TRACK_WIDTH_METRES, MIN_COASTER_TRACK_WIDTH_MM / scale)
-      : trackWidthMm / scale;
+    scale = longestSide > 0 ? COASTER_TARGET_ENVELOPE_MM / longestSide : 1;
 
     const centreX = (effectiveBasePlate.minX + effectiveBasePlate.maxX) / 2;
     const centreY = (effectiveBasePlate.minY + effectiveBasePlate.maxY) / 2;
@@ -293,8 +377,8 @@ export function buildTrackModel({
       : orientedGeometry.projectedNodes;
     workingSecondaries = orientedSecondaries.map(nodes => nodes.map(n => translatePoint(n, dx, dy)));
 
-    // Rebuild outlines at the chosen ribbon width. The base-plate pocket,
-    // ribbon mesh, and text-placement obstacle all derive from this outline.
+    // Re-buffer outlines around the translated nodes (translation alone is
+    // enough mathematically, but rebuilding keeps a single code path).
     workingOutline = workingProjected?.length
       ? buildTrackOutline(workingProjected, effectiveTrackWidthMetres)
       : translateOutline(orientedGeometry.outlinePoints, dx, dy);
@@ -313,13 +397,6 @@ export function buildTrackModel({
     };
   } else {
     scale = computeScale(effectiveBasePlate);
-    if (!trackWidthAuto) {
-      effectiveTrackWidthMetres = trackWidthMm / scale;
-      if (workingProjected?.length) {
-        workingOutline = buildTrackOutline(workingProjected, effectiveTrackWidthMetres);
-      }
-      workingSecondaryOutlines = workingSecondaries.map(nodes => buildTrackOutline(nodes, effectiveTrackWidthMetres));
-    }
   }
 
   const ribbonOptions = coasterMode
@@ -329,9 +406,9 @@ export function buildTrackModel({
         baseZ: coasterInlay === 'flush' ? BASE_THICKNESS_MM - COASTER_POCKET_DEPTH_MM : BASE_THICKNESS_MM,
         trackWidthMetres: effectiveTrackWidthMetres,
       }
-    : (effectiveTrackWidthMetres !== TRACK_WIDTH_METRES
-        ? { trackWidthMetres: effectiveTrackWidthMetres }
-        : undefined);
+    : (trackWidthAuto
+        ? undefined
+        : { trackWidthMetres: effectiveTrackWidthMetres });
 
   // Text placement uses all visible layouts as obstacles in combined mode.
   const allOutlinePoints = workingSecondaryOutlines.length > 0

--- a/src/model/track-model.ts
+++ b/src/model/track-model.ts
@@ -118,6 +118,14 @@ export interface BuildTrackModelOptions {
    * 'flush' cuts the track shape clean through the base and fills it with a full-height plug.
    */
   coasterInlay?: 'flush' | 'raised';
+  /**
+   * When true (default), the printed ribbon width is auto-derived:
+   * non-coaster uses TRACK_WIDTH_METRES; coaster clamps to MIN_COASTER_TRACK_WIDTH_MM.
+   * When false, `trackWidthMm` overrides in both modes.
+   */
+  trackWidthAuto?: boolean;
+  /** User-selected printed ribbon width in mm; used when trackWidthAuto is false. */
+  trackWidthMm?: number;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -167,6 +175,8 @@ export function buildTrackModel({
   coasterMode = false,
   coasterShape = 'round',
   coasterInlay = 'raised',
+  trackWidthAuto = true,
+  trackWidthMm = 2,
 }: BuildTrackModelOptions): TrackModel {
   const normalizedPrimaryOrientationDeg = normalizePrimaryOrientationDeg(
     primaryOrientationDeg === undefined
@@ -254,21 +264,24 @@ export function buildTrackModel({
     ? (buildCombinedBasePlate([orientedGeometry.outlinePoints, ...secondaryOutlines]) ?? orientedGeometry.basePlate)
     : orientedGeometry.basePlate;
 
-  // ── Coaster mode geometry setup ────────────────────────────────────────────
-  // Translate all geometry so the track's bounding-box centre sits at (0, 0),
-  // aligning with the coaster mesh which is rendered centred on the origin.
+  // ── Geometry & ribbon width setup ──────────────────────────────────────────
+  // Coaster mode translates geometry so the track's bounding-box centre sits at
+  // (0, 0), aligning with the coaster mesh which is rendered centred on the
+  // origin. Non-coaster mode keeps geometry in its original frame.
   let workingOutline = orientedGeometry.outlinePoints;
   let workingProjected = orientedGeometry.projectedNodes;
   let workingSecondaryOutlines = secondaryOutlines;
   let workingSecondaries = orientedSecondaries;
   let scale: number;
-  let coasterTrackWidthMetres = TRACK_WIDTH_METRES;
+  let effectiveTrackWidthMetres = TRACK_WIDTH_METRES;
 
   if (coasterMode) {
     const targetEnvelopeMm = COASTER_SIZE_MM - 2 * (COASTER_INNER_MARGIN_MM + BASE_CORNER_RADIUS_MM);
     const longestSide = Math.max(effectiveBasePlate.width, effectiveBasePlate.height);
     scale = longestSide > 0 ? targetEnvelopeMm / longestSide : 1;
-    coasterTrackWidthMetres = Math.max(TRACK_WIDTH_METRES, MIN_COASTER_TRACK_WIDTH_MM / scale);
+    effectiveTrackWidthMetres = trackWidthAuto
+      ? Math.max(TRACK_WIDTH_METRES, MIN_COASTER_TRACK_WIDTH_MM / scale)
+      : trackWidthMm / scale;
 
     const centreX = (effectiveBasePlate.minX + effectiveBasePlate.maxX) / 2;
     const centreY = (effectiveBasePlate.minY + effectiveBasePlate.maxY) / 2;
@@ -280,13 +293,12 @@ export function buildTrackModel({
       : orientedGeometry.projectedNodes;
     workingSecondaries = orientedSecondaries.map(nodes => nodes.map(n => translatePoint(n, dx, dy)));
 
-    // Rebuild outlines with a ribbon width that prints at least
-    // MIN_COASTER_TRACK_WIDTH_MM. The base-plate pocket, ribbon mesh, and
-    // text-placement obstacle all derive from the same wider outline.
+    // Rebuild outlines at the chosen ribbon width. The base-plate pocket,
+    // ribbon mesh, and text-placement obstacle all derive from this outline.
     workingOutline = workingProjected?.length
-      ? buildTrackOutline(workingProjected, coasterTrackWidthMetres)
+      ? buildTrackOutline(workingProjected, effectiveTrackWidthMetres)
       : translateOutline(orientedGeometry.outlinePoints, dx, dy);
-    workingSecondaryOutlines = workingSecondaries.map(nodes => buildTrackOutline(nodes, coasterTrackWidthMetres));
+    workingSecondaryOutlines = workingSecondaries.map(nodes => buildTrackOutline(nodes, effectiveTrackWidthMetres));
 
     // Synthetic base plate: a 90 mm square centred at origin, expressed in metres.
     // When scaled by `scale` it produces a 90×90 mm Rect2D for text placement.
@@ -301,6 +313,13 @@ export function buildTrackModel({
     };
   } else {
     scale = computeScale(effectiveBasePlate);
+    if (!trackWidthAuto) {
+      effectiveTrackWidthMetres = trackWidthMm / scale;
+      if (workingProjected?.length) {
+        workingOutline = buildTrackOutline(workingProjected, effectiveTrackWidthMetres);
+      }
+      workingSecondaryOutlines = workingSecondaries.map(nodes => buildTrackOutline(nodes, effectiveTrackWidthMetres));
+    }
   }
 
   const ribbonOptions = coasterMode
@@ -308,9 +327,11 @@ export function buildTrackModel({
         trackHeightMm: coasterInlay === 'flush' ? COASTER_TRACK_HEIGHT_FLUSH_MM : COASTER_TRACK_HEIGHT_RAISED_MM,
         ignoreElevation: true,
         baseZ: coasterInlay === 'flush' ? BASE_THICKNESS_MM - COASTER_POCKET_DEPTH_MM : BASE_THICKNESS_MM,
-        trackWidthMetres: coasterTrackWidthMetres,
+        trackWidthMetres: effectiveTrackWidthMetres,
       }
-    : undefined;
+    : (effectiveTrackWidthMetres !== TRACK_WIDTH_METRES
+        ? { trackWidthMetres: effectiveTrackWidthMetres }
+        : undefined);
 
   // Text placement uses all visible layouts as obstacles in combined mode.
   const allOutlinePoints = workingSecondaryOutlines.length > 0

--- a/src/model/track-ribbon.ts
+++ b/src/model/track-ribbon.ts
@@ -8,7 +8,7 @@ export const COASTER_TRACK_HEIGHT_FLUSH_MM = 1;     // fills a 1 mm pocket carve
 export const COASTER_TRACK_HEIGHT_RAISED_MM = 0.2;  // thin inlay sitting on top of the base
 export const TRACK_WIDTH_METRES = 12;
 /** Minimum ribbon width in coaster mode, in mm (thin tracks look fragile at small scales). */
-export const MIN_COASTER_TRACK_WIDTH_MM = 0.5;
+export const MIN_COASTER_TRACK_WIDTH_MM = 1.0;
 export const MAX_RIBBON_SECTION_STEP_METRES = 4;
 
 export interface RibbonMeshOptions {

--- a/src/stores/options.ts
+++ b/src/stores/options.ts
@@ -22,6 +22,17 @@ export const combinedLayoutMode = writable<boolean>(false);
 /** Elevation exaggeration multiplier (e.g. 1 = no exaggeration, 2 = double). */
 export const exaggeration = writable<number>(1);
 
+/**
+ * Whether to auto-derive the printed track width.
+ * When true: non-coaster uses TRACK_WIDTH_METRES (12 m); coaster uses
+ * max(TRACK_WIDTH_METRES, MIN_COASTER_TRACK_WIDTH_MM / scale).
+ * When false: width is taken from `trackWidthMm` directly.
+ */
+export const trackWidthAuto = writable<boolean>(true);
+
+/** User-selected printed track width in mm (used when trackWidthAuto is false). */
+export const trackWidthMm = writable<number>(2);
+
 /** Whether the model is built as a fixed-size 9x9 cm coaster with a level top. */
 export const coasterMode = writable<boolean>(false);
 

--- a/src/style.css
+++ b/src/style.css
@@ -667,7 +667,8 @@ body {
   margin-bottom: 12px;
 }
 
-#exaggeration-value {
+#exaggeration-value,
+#track-width-value {
   font-family: var(--font-mono);
   font-size: 1.15rem;
   font-weight: 700;
@@ -675,7 +676,8 @@ body {
   line-height: 1;
 }
 
-#exaggeration {
+#exaggeration,
+#track-width {
   width: 100%;
   appearance: none;
   height: 6px;
@@ -684,7 +686,13 @@ body {
   cursor: pointer;
 }
 
-#exaggeration::-webkit-slider-thumb {
+#track-width:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+#exaggeration::-webkit-slider-thumb,
+#track-width::-webkit-slider-thumb {
   appearance: none;
   width: 20px;
   height: 20px;
@@ -694,13 +702,37 @@ body {
   box-shadow: 0 4px 12px rgba(225, 6, 0, 0.35);
 }
 
-#exaggeration::-moz-range-thumb {
+#exaggeration::-moz-range-thumb,
+#track-width::-moz-range-thumb {
   width: 20px;
   height: 20px;
   border: 0;
   border-radius: 50%;
   background: var(--accent);
   box-shadow: 0 4px 12px rgba(225, 6, 0, 0.35);
+}
+
+#track-width:disabled::-webkit-slider-thumb {
+  background: rgba(99, 108, 128, 0.6);
+  box-shadow: none;
+}
+
+#track-width:disabled::-moz-range-thumb {
+  background: rgba(99, 108, 128, 0.6);
+  box-shadow: none;
+}
+
+.field-card label.track-width-auto {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 0 0;
+  cursor: pointer;
+  font-size: 0.78rem;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-muted);
+  font-family: var(--font-ui);
 }
 
 /* ── ExportBar ────────────────────────────────────────────── */

--- a/src/track-loader.ts
+++ b/src/track-loader.ts
@@ -32,6 +32,8 @@ import {
   coasterMode,
   coasterShape,
   coasterInlay,
+  trackWidthAuto,
+  trackWidthMm,
 } from './stores/options.js';
 import { statusMessage, statusIsError, previewOverlayState } from './stores/ui.js';
 import { placementDebugData } from './stores/debug.js';
@@ -134,6 +136,8 @@ export async function rebuildModel(elevationData: number[] | null = get(elevatio
       coasterMode: isCoaster,
       coasterShape: get(coasterShape),
       coasterInlay: get(coasterInlay),
+      trackWidthAuto: get(trackWidthAuto),
+      trackWidthMm: get(trackWidthMm),
     });
 
     nodes.set(layout.nodes);

--- a/src/workers/model-client.ts
+++ b/src/workers/model-client.ts
@@ -27,6 +27,10 @@ export interface ModelBuildParams {
   coasterShape?: 'round' | 'square';
   /** Coaster track inlay style (used only when coasterMode is true). */
   coasterInlay?: 'flush' | 'raised';
+  /** When true, auto-derive ribbon width; when false, use trackWidthMm directly. */
+  trackWidthAuto?: boolean;
+  /** User-selected printed ribbon width in mm (used when trackWidthAuto is false). */
+  trackWidthMm?: number;
 }
 
 type WorkerResponse = ModelBuildResponse | ModelBuildErrorResponse;
@@ -151,6 +155,8 @@ export function createModelWorkerClient(): {
       ...(params.coasterMode !== undefined ? { coasterMode: params.coasterMode } : {}),
       ...(params.coasterShape !== undefined ? { coasterShape: params.coasterShape } : {}),
       ...(params.coasterInlay !== undefined ? { coasterInlay: params.coasterInlay } : {}),
+      ...(params.trackWidthAuto !== undefined ? { trackWidthAuto: params.trackWidthAuto } : {}),
+      ...(params.trackWidthMm !== undefined ? { trackWidthMm: params.trackWidthMm } : {}),
     };
 
     return new Promise<TrackModel>((resolve, reject) => {

--- a/src/workers/model.worker.ts
+++ b/src/workers/model.worker.ts
@@ -29,6 +29,10 @@ export interface ModelBuildRequest {
   coasterShape?: 'round' | 'square';
   /** Coaster track inlay style (only used when coasterMode is true). */
   coasterInlay?: 'flush' | 'raised';
+  /** When true, auto-derive ribbon width; when false, use trackWidthMm directly. */
+  trackWidthAuto?: boolean;
+  /** User-selected printed ribbon width in mm (used when trackWidthAuto is false). */
+  trackWidthMm?: number;
 }
 
 export interface ModelBuildResponse {
@@ -126,6 +130,8 @@ function processLatest(): void {
       coasterMode: request.coasterMode ?? false,
       coasterShape: request.coasterShape ?? 'round',
       coasterInlay: request.coasterInlay ?? 'raised',
+      trackWidthAuto: request.trackWidthAuto ?? true,
+      trackWidthMm: request.trackWidthMm ?? 2,
     });
 
     // Flatten Triangle[] into a Float32Array (9 floats per triangle: 3 vertices × 3 coords).

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import { buildBasePlate } from '../src/geometry/outline.js';
 import { BASE_THICKNESS_MM, buildTrackModel, computeScale, exportStl } from '../src/model/index.js';
+import { MIN_COASTER_TRACK_WIDTH_MM } from '../src/model/track-ribbon.js';
 import type { Triangle, TrackModel, Vertex } from '../src/types/model.js';
 
 type Bounds = { minX: number; maxX: number; minY: number; maxY: number; minZ: number; maxZ: number };
@@ -538,4 +539,151 @@ test('exportStl returns download metadata with a blob, buffer, and filename', ()
   assert.ok(result.buffer instanceof ArrayBuffer);
   assert.ok(result.byteLength > 0);
   assert.equal(result.triangleCount, model.triangles.length);
+});
+
+// ── Track-width slider tests ───────────────────────────────────────────────────
+//
+// These exercise the trackWidthAuto / trackWidthMm path. We use a long
+// horizontal straight track and a fixed orientation so the ribbon's printed
+// width sits along Y and equals max(Y) - min(Y) of the track triangles.
+
+function buildStraightTrackModel(opts: {
+  trackWidthAuto?: boolean;
+  trackWidthMm?: number;
+  coasterMode?: boolean;
+  trackName?: string;
+} = {}) {
+  return buildTrackModel({
+    outlinePoints: null,
+    basePlate: null,
+    trackName: opts.trackName,
+    projectedNodes: [
+      { x: 0, y: 0, elevation: 0 },
+      { x: 1000, y: 0, elevation: 0 },
+    ],
+    primaryOrientationDeg: 0,
+    ...(opts.coasterMode !== undefined ? { coasterMode: opts.coasterMode } : {}),
+    ...(opts.trackWidthAuto !== undefined ? { trackWidthAuto: opts.trackWidthAuto } : {}),
+    ...(opts.trackWidthMm !== undefined ? { trackWidthMm: opts.trackWidthMm } : {}),
+  });
+}
+
+function trackRibbonYSpanMm(model: TrackModel): number {
+  const tris = trackTriangles(model);
+  if (tris.length === 0) return 0;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const tri of tris) {
+    for (const v of tri) {
+      if (v.y < minY) minY = v.y;
+      if (v.y > maxY) maxY = v.y;
+    }
+  }
+  return maxY - minY;
+}
+
+test('buildTrackModel applies trackWidthMm in non-coaster manual mode', () => {
+  const auto = buildStraightTrackModel({ trackWidthAuto: true });
+  const manual = buildStraightTrackModel({ trackWidthAuto: false, trackWidthMm: 5 });
+
+  approxEqual(trackRibbonYSpanMm(manual), 5, 0.05);
+  assert.ok(
+    trackRibbonYSpanMm(manual) > trackRibbonYSpanMm(auto),
+    'manual 5 mm should be wider than the default 12 m at coaster scale',
+  );
+});
+
+test('buildTrackModel scales trackWidthMm linearly across the slider range', () => {
+  const narrow = buildStraightTrackModel({ trackWidthAuto: false, trackWidthMm: 2 });
+  const wide = buildStraightTrackModel({ trackWidthAuto: false, trackWidthMm: 8 });
+
+  approxEqual(trackRibbonYSpanMm(narrow), 2, 0.05);
+  approxEqual(trackRibbonYSpanMm(wide), 8, 0.05);
+});
+
+test('buildTrackModel coaster auto mode clamps to MIN_COASTER_TRACK_WIDTH_MM', () => {
+  const model = buildStraightTrackModel({ trackWidthAuto: true, coasterMode: true });
+
+  // Default 12 m at coaster scale on a 1 km track is < 1 mm, so the auto
+  // formula should widen the ribbon to exactly MIN_COASTER_TRACK_WIDTH_MM.
+  approxEqual(trackRibbonYSpanMm(model), MIN_COASTER_TRACK_WIDTH_MM, 0.05);
+});
+
+test('buildTrackModel coaster manual mode applies trackWidthMm', () => {
+  const model = buildStraightTrackModel({
+    trackWidthAuto: false,
+    trackWidthMm: 4,
+    coasterMode: true,
+  });
+
+  approxEqual(trackRibbonYSpanMm(model), 4, 0.1);
+});
+
+test('buildTrackModel rebuilds correct geometry across width changes with the same cache token', () => {
+  // Reproduces the "stale auto-orientation placements" bug: with auto orientation
+  // and a shared cache token, switching from auto to manual width must produce
+  // a ribbon at the requested width — not one buffered against the prior outline.
+  const token = {};
+  const projectedNodes = [
+    { x: 0, y: 0, elevation: 0 },
+    { x: 1000, y: 0, elevation: 0 },
+  ];
+
+  const auto = buildTrackModel({
+    outlinePoints: null,
+    basePlate: null,
+    trackName: 'TEST',
+    projectedNodes,
+    primaryOrientationDeg: 0,
+    placementCacheToken: token,
+    trackWidthAuto: true,
+  });
+
+  const manual = buildTrackModel({
+    outlinePoints: null,
+    basePlate: null,
+    trackName: 'TEST',
+    projectedNodes,
+    primaryOrientationDeg: 0,
+    placementCacheToken: token,
+    trackWidthAuto: false,
+    trackWidthMm: 7,
+  });
+
+  approxEqual(trackRibbonYSpanMm(manual), 7, 0.05);
+  assert.ok(trackRibbonYSpanMm(manual) > trackRibbonYSpanMm(auto));
+});
+
+test('buildTrackModel auto orientation uses the user-selected width for outline construction', () => {
+  // When auto orientation runs, its outlines (used for landscape & text-bottom
+  // scoring) must reflect the chosen width — otherwise orientation can drift.
+  // We assert the rendered ribbon matches the requested width even when auto
+  // orientation is active.
+  const model = buildTrackModel({
+    outlinePoints: null,
+    basePlate: null,
+    trackName: 'TEST',
+    projectedNodes: [
+      { x: 0, y: 0, elevation: 0 },
+      { x: 1500, y: 0, elevation: 0 },
+    ],
+    // primaryOrientationDeg omitted -> defaults to 'auto'
+    trackWidthAuto: false,
+    trackWidthMm: 6,
+  });
+
+  // Auto may rotate; pick the smaller span (the across-ribbon axis) which
+  // should equal the requested width.
+  const tris = trackTriangles(model);
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+  for (const tri of tris) {
+    for (const v of tri) {
+      if (v.x < minX) minX = v.x;
+      if (v.x > maxX) maxX = v.x;
+      if (v.y < minY) minY = v.y;
+      if (v.y > maxY) maxY = v.y;
+    }
+  }
+  const acrossRibbon = Math.min(maxX - minX, maxY - minY);
+  approxEqual(acrossRibbon, 6, 0.05);
 });


### PR DESCRIPTION
## Summary
- Adds a "Track width" slider (1–10 mm, 0.5 mm step) with an **Auto** checkbox to the options panel, visible in both normal and coaster modes.
- **Auto mode** preserves prior behaviour: `TRACK_WIDTH_METRES` (12 m) in normal mode; clamped to `MIN_COASTER_TRACK_WIDTH_MM` in coaster mode.
- **Manual mode** applies the slider value (mm) as the printed ribbon width in both modes by computing `trackWidthMm / scale` and rebuilding the outline + ribbon mesh.
- Restores `MIN_COASTER_TRACK_WIDTH_MM` to 1.0 mm (the auto-mode floor).

The two new options are plumbed through `track-loader → model-client → model.worker → buildTrackModel`. Slider changes are debounced 150 ms and invalidate the placement cache so text placement re-runs against the new outline.

## Test plan
- [ ] Load a few circuits in normal mode; toggle Auto off and confirm the ribbon width responds to the slider (1–10 mm).
- [ ] Switch to coaster mode; with Auto on, confirm the ribbon clamps to 1 mm minimum on small-scale circuits.
- [ ] In coaster mode, toggle Auto off and sweep the slider — confirm the inlay/pocket/text obstacles all stay in sync at the new width.
- [ ] Confirm the slider is disabled (greyed) when Auto is checked.
- [ ] Export STL/3MF in both auto and manual modes and inspect ribbon thickness in a slicer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)