### PR TITLE
Reduce 3MF non-manifold edges in coaster exports

### DIFF
--- a/src/export/stl.ts
+++ b/src/export/stl.ts
@@ -3,6 +3,7 @@
  * Safe to use in Web Workers.
  */
 
+import { isDegenerateTriangle } from '../model/mesh-primitives.js';
 import type { TrackModel, Triangle, Vertex } from '../types/model.js';
 
 export function computeNormal(a: Vertex, b: Vertex, c: Vertex): Vertex {
@@ -25,25 +26,14 @@ export function computeNormal(a: Vertex, b: Vertex, c: Vertex): Vertex {
   };
 }
 
-const STL_QUANTIZATION_MM = 1e-4;
-const STL_AREA_TOLERANCE_MM2 = 1e-6;
-
-function isStlDegenerate(a: Vertex, b: Vertex, c: Vertex): boolean {
-  const q = (v: number): number => Math.round(v / STL_QUANTIZATION_MM) * STL_QUANTIZATION_MM;
-  const ax = q(a.x), ay = q(a.y), az = q(a.z);
-  const bx = q(b.x), by = q(b.y), bz = q(b.z);
-  const cx = q(c.x), cy = q(c.y), cz = q(c.z);
-  const abx = bx - ax, aby = by - ay, abz = bz - az;
-  const acx = cx - ax, acy = cy - ay, acz = cz - az;
-  const nx = aby * acz - abz * acy;
-  const ny = abz * acx - abx * acz;
-  const nz = abx * acy - aby * acx;
-  return Math.hypot(nx, ny, nz) / 2 < STL_AREA_TOLERANCE_MM2;
-}
-
 export function serializeBinaryStl(triangles: Triangle[], solidName = 'racetrack-3d'): ArrayBuffer {
   const safeName = String(solidName).replace(/[^\x20-\x7e]+/g, ' ').slice(0, 80);
-  const kept = triangles.filter(([a, b, c]) => !isStlDegenerate(a, b, c));
+  // Drop only triangles whose vertices coincide on the export grid, using the
+  // shared definition so STL agrees with the 3MF writer. Crucially this is
+  // coincidence-only, not area-based: an area filter also removes thin-but-real
+  // collinear slivers that carry edge-pairing, which opens holes in this
+  // single-soup mesh.
+  const kept = triangles.filter(([a, b, c]) => !isDegenerateTriangle(a, b, c));
   const triangleCount = kept.length;
   const buffer = new ArrayBuffer(84 + triangleCount * 50);
   const view = new DataView(buffer);

--- a/src/export/stl.ts
+++ b/src/export/stl.ts
@@ -25,9 +25,26 @@ export function computeNormal(a: Vertex, b: Vertex, c: Vertex): Vertex {
   };
 }
 
+const STL_QUANTIZATION_MM = 1e-4;
+const STL_AREA_TOLERANCE_MM2 = 1e-6;
+
+function isStlDegenerate(a: Vertex, b: Vertex, c: Vertex): boolean {
+  const q = (v: number): number => Math.round(v / STL_QUANTIZATION_MM) * STL_QUANTIZATION_MM;
+  const ax = q(a.x), ay = q(a.y), az = q(a.z);
+  const bx = q(b.x), by = q(b.y), bz = q(b.z);
+  const cx = q(c.x), cy = q(c.y), cz = q(c.z);
+  const abx = bx - ax, aby = by - ay, abz = bz - az;
+  const acx = cx - ax, acy = cy - ay, acz = cz - az;
+  const nx = aby * acz - abz * acy;
+  const ny = abz * acx - abx * acz;
+  const nz = abx * acy - aby * acx;
+  return Math.hypot(nx, ny, nz) / 2 < STL_AREA_TOLERANCE_MM2;
+}
+
 export function serializeBinaryStl(triangles: Triangle[], solidName = 'racetrack-3d'): ArrayBuffer {
   const safeName = String(solidName).replace(/[^\x20-\x7e]+/g, ' ').slice(0, 80);
-  const triangleCount = triangles.length;
+  const kept = triangles.filter(([a, b, c]) => !isStlDegenerate(a, b, c));
+  const triangleCount = kept.length;
   const buffer = new ArrayBuffer(84 + triangleCount * 50);
   const view = new DataView(buffer);
   const header = new Uint8Array(buffer, 0, 80);
@@ -39,7 +56,7 @@ export function serializeBinaryStl(triangles: Triangle[], solidName = 'racetrack
   view.setUint32(80, triangleCount, true);
 
   let offset = 84;
-  for (const [a, b, c] of triangles) {
+  for (const [a, b, c] of kept) {
     const normal = computeNormal(a, b, c);
     const values = [
       normal.x, normal.y, normal.z,

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -4,6 +4,7 @@
  */
 
 import { strToU8, zipSync } from 'fflate';
+import { isDegenerateTriangle } from '../model/mesh-primitives.js';
 import { splitModelTriangles as _splitModelTriangles } from '../model/triangle-groups.js';
 import type { TrackModel, Triangle, Vertex } from '../types/model.js';
 
@@ -53,14 +54,19 @@ function buildPart(
   }
 
   for (const triangle of triangles) {
-    const v1 = getVertexIndex(triangle[0]);
-    const v2 = getVertexIndex(triangle[1]);
-    const v3 = getVertexIndex(triangle[2]);
-    // Drop triangles that collapse after vertex dedup (zero-area slivers).
-    if (v1 === v2 || v2 === v3 || v1 === v3) {
+    // Drop triangles whose vertices coincide after the export's grid dedup
+    // (zero-area slivers that would leave a non-manifold boundary). Uses the
+    // shared coincidence-only definition from mesh-primitives so the writer is
+    // robust even for triangles that reach it without passing through
+    // `addTriangle`, and stays consistent with the STL writer.
+    if (isDegenerateTriangle(triangle[0], triangle[1], triangle[2])) {
       continue;
     }
-    triangleEntries.push({ v1, v2, v3 });
+    triangleEntries.push({
+      v1: getVertexIndex(triangle[0]),
+      v2: getVertexIndex(triangle[1]),
+      v3: getVertexIndex(triangle[2]),
+    });
   }
 
   if (triangleEntries.length === 0) {

--- a/src/export/threemf.ts
+++ b/src/export/threemf.ts
@@ -19,11 +19,24 @@ function formatCoordinate(value: number): string {
   return (Math.round(value * 10000) / 10000).toFixed(4);
 }
 
-export function build3mfModelXml(model: TrackModel): string {
+/**
+ * Builds a vertex/triangle table for a single triangle group, with vertex
+ * dedup scoped to the group. Keeping each part's mesh separate is what
+ * makes the 3MF a multi-object file: each `<object>` owns its own vertex
+ * pool, so coplanar pocket walls in different parts can't be merged into
+ * non-2-manifold edges.
+ */
+function buildPart(
+  triangles: Triangle[],
+  colorIndex: number,
+): { vertexXml: string; triangleXml: string } | null {
+  if (triangles.length === 0) {
+    return null;
+  }
+
   const vertexIndexes = new Map<string, number>();
   const vertices: { x: string; y: string; z: string }[] = [];
-  const triangleEntries: { v1: number; v2: number; v3: number; colorIndex: number }[] = [];
-  const { baseTriangles, secondaryTrackTriangles, trackTriangles } = splitModelTriangles(model);
+  const triangleEntries: { v1: number; v2: number; v3: number }[] = [];
 
   function getVertexIndex(vertex: Vertex): number {
     const x = formatCoordinate(vertex.x);
@@ -39,26 +52,68 @@ export function build3mfModelXml(model: TrackModel): string {
     return vertexIndexes.get(key) as number;
   }
 
-  function addTriangles(triangles: [Vertex, Vertex, Vertex][], colorIndex: number): void {
-    for (const triangle of triangles) {
-      triangleEntries.push({
-        v1: getVertexIndex(triangle[0]),
-        v2: getVertexIndex(triangle[1]),
-        v3: getVertexIndex(triangle[2]),
-        colorIndex,
-      });
+  for (const triangle of triangles) {
+    const v1 = getVertexIndex(triangle[0]);
+    const v2 = getVertexIndex(triangle[1]);
+    const v3 = getVertexIndex(triangle[2]);
+    // Drop triangles that collapse after vertex dedup (zero-area slivers).
+    if (v1 === v2 || v2 === v3 || v1 === v3) {
+      continue;
     }
+    triangleEntries.push({ v1, v2, v3 });
   }
 
-  addTriangles(baseTriangles, 0);
-  addTriangles(secondaryTrackTriangles ?? [], 2);
-  addTriangles(trackTriangles, 1);
+  if (triangleEntries.length === 0) {
+    return null;
+  }
 
   const vertexXml = vertices
     .map(vertex => `          <vertex x="${vertex.x}" y="${vertex.y}" z="${vertex.z}"/>`)
     .join('\n');
   const triangleXml = triangleEntries
-    .map(triangle => `          <triangle v1="${triangle.v1}" v2="${triangle.v2}" v3="${triangle.v3}" pid="1" p1="${triangle.colorIndex}"/>`)
+    .map(triangle => `          <triangle v1="${triangle.v1}" v2="${triangle.v2}" v3="${triangle.v3}" pid="1" p1="${colorIndex}"/>`)
+    .join('\n');
+
+  return { vertexXml, triangleXml };
+}
+
+export function build3mfModelXml(model: TrackModel): string {
+  const { baseTriangles, secondaryTrackTriangles, trackTriangles } = splitModelTriangles(model);
+
+  // One <object> per logical part, each with its own vertex pool. This keeps
+  // the parts independently 2-manifold even when they share coplanar
+  // boundaries (e.g. flush coaster pocket walls vs. inlay walls), where a
+  // single shared mesh would have edges incident to four faces.
+  const parts: { id: number; pindex: number; vertexXml: string; triangleXml: string }[] = [];
+
+  // Allocate object IDs sequentially; object id "1" would conflict with
+  // colorgroup id "1" in some readers, so we start at 2.
+  let nextId = 2;
+  function tryAdd(triangles: Triangle[], colorIndex: number): void {
+    const part = buildPart(triangles, colorIndex);
+    if (part) {
+      parts.push({ id: nextId++, pindex: colorIndex, ...part });
+    }
+  }
+
+  tryAdd(baseTriangles, 0);
+  tryAdd(secondaryTrackTriangles ?? [], 2);
+  tryAdd(trackTriangles, 1);
+
+  const objectsXml = parts
+    .map(part => `    <object id="${part.id}" type="model" pid="1" pindex="${part.pindex}">
+      <mesh>
+        <vertices>
+${part.vertexXml}
+        </vertices>
+        <triangles>
+${part.triangleXml}
+        </triangles>
+      </mesh>
+    </object>`)
+    .join('\n');
+  const buildXml = parts
+    .map(part => `    <item objectid="${part.id}"/>`)
     .join('\n');
 
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -71,19 +126,10 @@ export function build3mfModelXml(model: TrackModel): string {
       <m:color color="#E8002D"/>
       <m:color color="#888888"/>
     </m:colorgroup>
-    <object id="2" type="model" pid="1" pindex="0">
-      <mesh>
-        <vertices>
-${vertexXml}
-        </vertices>
-        <triangles>
-${triangleXml}
-        </triangles>
-      </mesh>
-    </object>
+${objectsXml}
   </resources>
   <build>
-    <item objectid="2"/>
+${buildXml}
   </build>
 </model>`;
 }

--- a/src/model/base-plate.ts
+++ b/src/model/base-plate.ts
@@ -64,11 +64,17 @@ export function buildRoundedRectangleRing(
   ring.push({ x: minX, y: minY + radiusMm });
   appendRoundedArc(ring, minX + radiusMm, minY + radiusMm, radiusMm, 180, 270, segmentsPerCorner);
 
-  // The final arc lands exactly on the first explicit point — drop the duplicate
-  // so the closed ring has each vertex exactly once.
+  // The final arc closes onto the first explicit point, but `Math.cos(270°)`
+  // leaves a sub-ULP residual whose survival depends on coordinate magnitude,
+  // so an exact `===` would miss the duplicate near the origin. Compare with an
+  // epsilon below the export grid to drop the closing vertex reliably.
+  const RING_CLOSE_EPSILON_MM = 1e-6;
   const first = ring[0]!;
   const last = ring[ring.length - 1]!;
-  if (first.x === last.x && first.y === last.y) {
+  if (
+    Math.abs(first.x - last.x) < RING_CLOSE_EPSILON_MM
+    && Math.abs(first.y - last.y) < RING_CLOSE_EPSILON_MM
+  ) {
     ring.pop();
   }
 

--- a/src/model/base-plate.ts
+++ b/src/model/base-plate.ts
@@ -64,6 +64,14 @@ export function buildRoundedRectangleRing(
   ring.push({ x: minX, y: minY + radiusMm });
   appendRoundedArc(ring, minX + radiusMm, minY + radiusMm, radiusMm, 180, 270, segmentsPerCorner);
 
+  // The final arc lands exactly on the first explicit point — drop the duplicate
+  // so the closed ring has each vertex exactly once.
+  const first = ring[0]!;
+  const last = ring[ring.length - 1]!;
+  if (first.x === last.x && first.y === last.y) {
+    ring.pop();
+  }
+
   return ring;
 }
 
@@ -166,6 +174,68 @@ function normalizeToCounterClockwise(ring: Point2D[]): Point2D[] {
 }
 
 /**
+ * Quantization grid (mm) used to dedup pocket polygon vertices. Matches the
+ * 4-decimal grid the 3MF exporter uses, so any vertices that would collapse
+ * after export are removed up-front instead of producing degenerate sliver
+ * triangles in earcut output.
+ */
+const POCKET_RING_QUANTIZATION_MM = 1e-4;
+/**
+ * Removes vertices that are colinear with their neighbours under the
+ * 4-decimal quantization grid. Earcut emits zero-area sliver triangles
+ * along long straight sections of the buffered track outline (turf.buffer
+ * subdivides those liberally), and the slivers produce 1-incidence open
+ * edges in the earcut output.
+ */
+function simplifyRing(ring: Point2D[]): Point2D[] {
+  if (ring.length < 3) {
+    return ring;
+  }
+  const q = (v: number): number => Math.round(v / POCKET_RING_QUANTIZATION_MM) * POCKET_RING_QUANTIZATION_MM;
+
+  // Step 1: drop consecutive duplicates at quantization precision.
+  const deduped: Point2D[] = [];
+  for (const point of ring) {
+    const qx = q(point.x);
+    const qy = q(point.y);
+    const last = deduped[deduped.length - 1];
+    if (last && q(last.x) === qx && q(last.y) === qy) {
+      continue;
+    }
+    deduped.push(point);
+  }
+  if (deduped.length > 1) {
+    const first = deduped[0]!;
+    const last = deduped[deduped.length - 1]!;
+    if (q(first.x) === q(last.x) && q(first.y) === q(last.y)) {
+      deduped.pop();
+    }
+  }
+  if (deduped.length < 3) {
+    return deduped;
+  }
+
+  // Step 2: drop colinear interior vertices using cross-product on quantized
+  // coords. Tolerance is one quantization unit squared — anything below
+  // that lies on the line through its neighbours after dedup.
+  const out: Point2D[] = [];
+  for (let i = 0; i < deduped.length; i += 1) {
+    const prev = deduped[(i - 1 + deduped.length) % deduped.length]!;
+    const curr = deduped[i]!;
+    const next = deduped[(i + 1) % deduped.length]!;
+    const ax = q(prev.x), ay = q(prev.y);
+    const bx = q(curr.x), by = q(curr.y);
+    const cx = q(next.x), cy = q(next.y);
+    const cross = (bx - ax) * (cy - by) - (by - ay) * (cx - bx);
+    if (Math.abs(cross) <= POCKET_RING_QUANTIZATION_MM * POCKET_RING_QUANTIZATION_MM) {
+      continue;
+    }
+    out.push(curr);
+  }
+  return out.length >= 3 ? out : deduped;
+}
+
+/**
  * Builds a fixed 90 mm coaster base plate centred at the origin. Optional
  * `pockets` are shallow recesses cut into the top surface (not through the
  * base), used in flush-inlay mode to seat the coloured track prism flush with
@@ -192,11 +262,12 @@ export function buildCoasterBasePlateMesh(
   const validPockets = pockets
     .filter(p => p.boundary.length >= 3)
     .map(p => ({
-      boundary: normalizeToCounterClockwise(p.boundary),
+      boundary: simplifyRing(normalizeToCounterClockwise(p.boundary)),
       islands: (p.islands ?? [])
         .filter(island => island.length >= 3)
-        .map(normalizeToCounterClockwise),
-    }));
+        .map(island => simplifyRing(normalizeToCounterClockwise(island))),
+    }))
+    .filter(p => p.boundary.length >= 3);
 
   const minZ = 0;
   const maxZ = BASE_THICKNESS_MM;

--- a/src/model/mesh-primitives.ts
+++ b/src/model/mesh-primitives.ts
@@ -5,7 +5,39 @@ export function createVertex(x: number, y: number, z: number): Vertex {
   return { x, y, z };
 }
 
+/**
+ * Quantization grid (mm). Matches the 4-decimal precision in
+ * `formatCoordinate` (src/export/threemf.ts) so we only filter triangles
+ * that genuinely collapse after the export's vertex dedup.
+ */
+const DEGENERATE_QUANTIZATION_MM = 1e-4;
+
+function quantize(value: number): number {
+  return Math.round(value / DEGENERATE_QUANTIZATION_MM) * DEGENERATE_QUANTIZATION_MM;
+}
+
+/**
+ * Returns true only when two of the triangle's vertices collapse to the
+ * same point under the 3MF's 1e-4 mm vertex dedup. This is the exact
+ * condition for a triangle to disappear in the exported file and leave a
+ * non-manifold boundary; small-but-nonzero slivers are preserved so the
+ * mesh stays closed around fine glyph features.
+ */
+export function isDegenerateTriangle(a: Vertex, b: Vertex, c: Vertex): boolean {
+  const ax = quantize(a.x), ay = quantize(a.y), az = quantize(a.z);
+  const bx = quantize(b.x), by = quantize(b.y), bz = quantize(b.z);
+  const cx = quantize(c.x), cy = quantize(c.y), cz = quantize(c.z);
+  return (
+    (ax === bx && ay === by && az === bz) ||
+    (bx === cx && by === cy && bz === cz) ||
+    (ax === cx && ay === cy && az === cz)
+  );
+}
+
 export function addTriangle(triangles: Triangle[], a: Vertex, b: Vertex, c: Vertex): void {
+  if (isDegenerateTriangle(a, b, c)) {
+    return;
+  }
   triangles.push([a, b, c]);
 }
 

--- a/src/model/mesh-primitives.ts
+++ b/src/model/mesh-primitives.ts
@@ -17,11 +17,22 @@ function quantize(value: number): number {
 }
 
 /**
- * Returns true only when two of the triangle's vertices collapse to the
- * same point under the 3MF's 1e-4 mm vertex dedup. This is the exact
- * condition for a triangle to disappear in the exported file and leave a
- * non-manifold boundary; small-but-nonzero slivers are preserved so the
- * mesh stays closed around fine glyph features.
+ * Returns true only when two of the triangle's vertices collapse to the same
+ * point under the 3MF's 1e-4 mm vertex dedup. This is the exact condition for a
+ * triangle to disappear on export and leave a non-manifold boundary.
+ *
+ * This is intentionally coincidence-only, *not* area-based: a thin but distinct
+ * sliver — three collinear-looking yet separate vertices — still contributes
+ * its edges to the mesh's edge-pairing. Dropping such triangles (as an
+ * area < tolerance test would) opens holes in the ribbon and pocket meshes,
+ * which is exactly the failure an STL area-filter previously introduced. So
+ * collinear-but-distinct triangles are deliberately kept; only genuine
+ * coincident-vertex collapses are removed.
+ *
+ * This is the single degeneracy definition shared by the STL and 3MF writers,
+ * so both agree on which triangles disappear. (The mesh validator's separate
+ * area-based `findDegenerateTriangles` is a stricter diagnostic, not an export
+ * filter.)
  */
 export function isDegenerateTriangle(a: Vertex, b: Vertex, c: Vertex): boolean {
   const ax = quantize(a.x), ay = quantize(a.y), az = quantize(a.z);

--- a/src/model/track-model.ts
+++ b/src/model/track-model.ts
@@ -447,23 +447,28 @@ export function buildTrackModel({
   // In flush coaster mode, the text also sits in a top-surface pocket flush
   // with the base top. Collect the chosen placement's glyph shapes so they can
   // be passed as additional pockets to the base plate builder.
-  // Each glyph gets a per-shape (x,y) perturbation of a few picometres so no
-  // two glyphs share collinear baseline vertices — earcut produces invalid
-  // triangulation (open boundary edges) when multiple holes share a line.
-  // The perturbation is far below the 1e-4 mm export quantization grid, so
-  // it's invisible in the print but breaks collinearity in the triangulator.
+  // Each glyph gets a unique sub-resolution (x, y) offset so no two glyphs
+  // share collinear baseline vertices — earcut produces invalid triangulation
+  // (open boundary edges) when multiple holes share a line. The offset is above
+  // the 1e-4 mm export grid (so vertices stay distinct after dedup) yet far
+  // below printer resolution (≈ 0.05 mm), so it breaks collinearity in the
+  // triangulator while staying invisible in the print.
   const textPocketSpecs: CoasterPocketSpec[] = [];
   if (coasterMode && coasterInlay === 'flush' && rankedPlacements) {
     const expanded = selectAndExpandPlacement(rankedPlacements, { textPositionRank: resolvedTextPositionRank });
     if (expanded?.contours?.length) {
       const shapes = collectShapes(buildContourTree(expanded.contours));
-      // Above the 1e-4 mm export quantization grid so vertices stay distinct
-      // after dedup, but well below printer resolution (≈ 0.05 mm) so it's
-      // invisible in the print. Each glyph gets a unique (dx, dy) offset.
-      const TEXT_POCKET_PERTURBATION_MM = 5e-4;
+      // Per-glyph step, capped so even a very long label's total drift stays
+      // bounded (≤ MAX_TEXT_POCKET_PERTURBATION_MM, still well under the
+      // ≈ 0.05 mm print resolution). For realistic labels `step` is the full
+      // PER_GLYPH_STEP_MM; it only shrinks once the glyph count would otherwise
+      // push the last glyph past the cap, and stays above the 1e-4 mm grid.
+      const PER_GLYPH_STEP_MM = 5e-4;
+      const MAX_TEXT_POCKET_PERTURBATION_MM = 0.03;
+      const step = Math.min(PER_GLYPH_STEP_MM, MAX_TEXT_POCKET_PERTURBATION_MM / Math.max(shapes.length, 1));
       shapes.forEach((shape, glyphIndex) => {
-        const dx = (glyphIndex + 1) * TEXT_POCKET_PERTURBATION_MM;
-        const dy = (glyphIndex + 1) * TEXT_POCKET_PERTURBATION_MM * 1.3;
+        const dx = (glyphIndex + 1) * step;
+        const dy = (glyphIndex + 1) * step * 1.3;
         const perturb = (p: Point2D): Point2D => ({ x: p.x + dx, y: p.y + dy });
         textPocketSpecs.push({
           boundary: shape.outer.map(perturb),

--- a/src/model/track-model.ts
+++ b/src/model/track-model.ts
@@ -462,7 +462,9 @@ export function buildTrackModel({
       // bounded (≤ MAX_TEXT_POCKET_PERTURBATION_MM, still well under the
       // ≈ 0.05 mm print resolution). For realistic labels `step` is the full
       // PER_GLYPH_STEP_MM; it only shrinks once the glyph count would otherwise
-      // push the last glyph past the cap, and stays above the 1e-4 mm grid.
+      // push the last glyph past the cap, and stays above the 1e-4 mm export
+      // grid for any plausible label (it would only reach the grid past ~300
+      // glyphs — far beyond a 90 mm coaster's capacity).
       const PER_GLYPH_STEP_MM = 5e-4;
       const MAX_TEXT_POCKET_PERTURBATION_MM = 0.03;
       const step = Math.min(PER_GLYPH_STEP_MM, MAX_TEXT_POCKET_PERTURBATION_MM / Math.max(shapes.length, 1));

--- a/src/model/track-model.ts
+++ b/src/model/track-model.ts
@@ -447,14 +447,29 @@ export function buildTrackModel({
   // In flush coaster mode, the text also sits in a top-surface pocket flush
   // with the base top. Collect the chosen placement's glyph shapes so they can
   // be passed as additional pockets to the base plate builder.
+  // Each glyph gets a per-shape (x,y) perturbation of a few picometres so no
+  // two glyphs share collinear baseline vertices — earcut produces invalid
+  // triangulation (open boundary edges) when multiple holes share a line.
+  // The perturbation is far below the 1e-4 mm export quantization grid, so
+  // it's invisible in the print but breaks collinearity in the triangulator.
   const textPocketSpecs: CoasterPocketSpec[] = [];
   if (coasterMode && coasterInlay === 'flush' && rankedPlacements) {
     const expanded = selectAndExpandPlacement(rankedPlacements, { textPositionRank: resolvedTextPositionRank });
     if (expanded?.contours?.length) {
       const shapes = collectShapes(buildContourTree(expanded.contours));
-      for (const shape of shapes) {
-        textPocketSpecs.push({ boundary: shape.outer, islands: shape.holes });
-      }
+      // Above the 1e-4 mm export quantization grid so vertices stay distinct
+      // after dedup, but well below printer resolution (≈ 0.05 mm) so it's
+      // invisible in the print. Each glyph gets a unique (dx, dy) offset.
+      const TEXT_POCKET_PERTURBATION_MM = 5e-4;
+      shapes.forEach((shape, glyphIndex) => {
+        const dx = (glyphIndex + 1) * TEXT_POCKET_PERTURBATION_MM;
+        const dy = (glyphIndex + 1) * TEXT_POCKET_PERTURBATION_MM * 1.3;
+        const perturb = (p: Point2D): Point2D => ({ x: p.x + dx, y: p.y + dy });
+        textPocketSpecs.push({
+          boundary: shape.outer.map(perturb),
+          islands: shape.holes.map(hole => hole.map(perturb)),
+        });
+      });
     }
   }
 

--- a/src/model/track-ribbon.ts
+++ b/src/model/track-ribbon.ts
@@ -114,12 +114,16 @@ export function buildRaisedRibbonMesh(
 
       const previous = sections[sections.length - 1];
 
+      // Match the 3MF export's vertex dedup grid (4 decimals → 1e-4 mm).
+      // Strict equality misses sections that round to the same coordinates,
+      // producing degenerate stitch quads in the merged mesh.
+      const SECTION_EPSILON_MM = 1.5e-4;
       if (
         previous
-        && previous.topLeft.x === section.topLeft.x
-        && previous.topLeft.y === section.topLeft.y
-        && previous.topRight.x === section.topRight.x
-        && previous.topRight.y === section.topRight.y
+        && Math.abs(previous.topLeft.x - section.topLeft.x) < SECTION_EPSILON_MM
+        && Math.abs(previous.topLeft.y - section.topLeft.y) < SECTION_EPSILON_MM
+        && Math.abs(previous.topRight.x - section.topRight.x) < SECTION_EPSILON_MM
+        && Math.abs(previous.topRight.y - section.topRight.y) < SECTION_EPSILON_MM
       ) {
         continue;
       }

--- a/src/model/validate-mesh.ts
+++ b/src/model/validate-mesh.ts
@@ -1,0 +1,141 @@
+/**
+ * Mesh validation utilities — used by tests and offline diagnostics to verify
+ * that the model.triangles list serialised by the export pipeline forms a
+ * 2-manifold mesh (every edge shared by exactly 2 triangles, no degenerate
+ * triangles).
+ *
+ * Quantization matches `formatCoordinate` in src/export/threemf.ts so the
+ * validator measures the mesh as Bambu Studio sees it after vertex dedup.
+ */
+
+import type { Triangle, Vertex } from '../types/model.js';
+
+/** 4-decimal quantization, matching `formatCoordinate` in src/export/threemf.ts. */
+const DEFAULT_PRECISION_MM = 1e-4;
+/** Triangles with cross-product magnitude below this (in mm²) are considered degenerate. */
+const DEFAULT_AREA_TOLERANCE_MM2 = 1e-6;
+
+function quantize(value: number, precision: number): number {
+  return Math.round(value / precision) * precision;
+}
+
+function vertexKey(v: Vertex, precision: number): string {
+  return `${quantize(v.x, precision)},${quantize(v.y, precision)},${quantize(v.z, precision)}`;
+}
+
+function edgeKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+function triangleArea(a: Vertex, b: Vertex, c: Vertex): number {
+  const abx = b.x - a.x, aby = b.y - a.y, abz = b.z - a.z;
+  const acx = c.x - a.x, acy = c.y - a.y, acz = c.z - a.z;
+  const nx = aby * acz - abz * acy;
+  const ny = abz * acx - abx * acz;
+  const nz = abx * acy - aby * acx;
+  return Math.hypot(nx, ny, nz) / 2;
+}
+
+export interface NonManifoldEdge {
+  /** The two endpoints, quantized. */
+  a: Vertex;
+  b: Vertex;
+  /** Indices into the triangles array that contain this edge. */
+  triangleIndices: number[];
+}
+
+export interface ValidateOptions {
+  precisionMm?: number;
+  areaToleranceMm2?: number;
+}
+
+/**
+ * Returns every edge whose triangle-incidence count is not exactly 2.
+ * Edges with count 1 are open boundaries; edges with count >= 3 indicate
+ * shared internal faces or T-junctions.
+ */
+export function findNonManifoldEdges(
+  triangles: Triangle[],
+  options: ValidateOptions = {},
+): NonManifoldEdge[] {
+  const precision = options.precisionMm ?? DEFAULT_PRECISION_MM;
+  const incidence = new Map<string, { a: Vertex; b: Vertex; indices: number[] }>();
+
+  for (let triIndex = 0; triIndex < triangles.length; triIndex += 1) {
+    const tri = triangles[triIndex]!;
+    const keys = tri.map(v => vertexKey(v, precision)) as [string, string, string];
+    for (let edge = 0; edge < 3; edge += 1) {
+      const ka = keys[edge]!;
+      const kb = keys[(edge + 1) % 3]!;
+      if (ka === kb) {
+        continue; // degenerate edge — handled by findDegenerateTriangles
+      }
+      const key = edgeKey(ka, kb);
+      const existing = incidence.get(key);
+      if (existing) {
+        existing.indices.push(triIndex);
+      } else {
+        incidence.set(key, {
+          a: tri[edge]!,
+          b: tri[(edge + 1) % 3]!,
+          indices: [triIndex],
+        });
+      }
+    }
+  }
+
+  const result: NonManifoldEdge[] = [];
+  for (const { a, b, indices } of incidence.values()) {
+    if (indices.length !== 2) {
+      result.push({ a, b, triangleIndices: indices });
+    }
+  }
+  return result;
+}
+
+/**
+ * Returns indices of triangles whose quantized cross-product area is below
+ * the tolerance — collapsed slivers that confuse slicer mesh checkers.
+ */
+export function findDegenerateTriangles(
+  triangles: Triangle[],
+  options: ValidateOptions = {},
+): number[] {
+  const precision = options.precisionMm ?? DEFAULT_PRECISION_MM;
+  const tolerance = options.areaToleranceMm2 ?? DEFAULT_AREA_TOLERANCE_MM2;
+  const result: number[] = [];
+
+  for (let i = 0; i < triangles.length; i += 1) {
+    const [a, b, c] = triangles[i]!;
+    const qa = { x: quantize(a.x, precision), y: quantize(a.y, precision), z: quantize(a.z, precision) };
+    const qb = { x: quantize(b.x, precision), y: quantize(b.y, precision), z: quantize(b.z, precision) };
+    const qc = { x: quantize(c.x, precision), y: quantize(c.y, precision), z: quantize(c.z, precision) };
+    if (triangleArea(qa, qb, qc) < tolerance) {
+      result.push(i);
+    }
+  }
+  return result;
+}
+
+export interface MeshSummary {
+  triangleCount: number;
+  uniqueVertexCount: number;
+  nonManifoldEdgeCount: number;
+  degenerateTriangleCount: number;
+}
+
+export function summarizeMesh(triangles: Triangle[], options: ValidateOptions = {}): MeshSummary {
+  const precision = options.precisionMm ?? DEFAULT_PRECISION_MM;
+  const uniqueVertices = new Set<string>();
+  for (const tri of triangles) {
+    for (const v of tri) {
+      uniqueVertices.add(vertexKey(v, precision));
+    }
+  }
+  return {
+    triangleCount: triangles.length,
+    uniqueVertexCount: uniqueVertices.size,
+    nonManifoldEdgeCount: findNonManifoldEdges(triangles, options).length,
+    degenerateTriangleCount: findDegenerateTriangles(triangles, options).length,
+  };
+}

--- a/src/text/mesh.ts
+++ b/src/text/mesh.ts
@@ -3,9 +3,9 @@ import type { Triangle, Vertex } from '../types/model.js';
 import type { RankedPlacements, FittedTextLayout, TextPlacementCandidate } from '../types/text.js';
 import type { Point2D } from '../types/geometry.js';
 import type { Rect2D } from '../types/text.js';
+import { addQuad, addTriangle } from '../model/mesh-primitives.js';
 import { buildContourTree, collectShapes, translateAndScaleContours, translateAndScaleBounds } from './contours.js';
 import type { ContourShape } from './contours.js';
-import { isDegenerateTriangle } from '../model/mesh-primitives.js';
 
 export const TEXT_HEIGHT_MM = 0.8;
 export const DEFAULT_TEXT_POSITION_RANK = 1;
@@ -21,18 +21,6 @@ export function normalizeTextPositionRank(value: unknown): number {
 
 function createVertex(x: number, y: number, z: number): Vertex {
   return { x, y, z };
-}
-
-function addTriangle(triangles: Triangle[], a: Vertex, b: Vertex, c: Vertex): void {
-  if (isDegenerateTriangle(a, b, c)) {
-    return;
-  }
-  triangles.push([a, b, c]);
-}
-
-function addQuad(triangles: Triangle[], a: Vertex, b: Vertex, c: Vertex, d: Vertex): void {
-  addTriangle(triangles, a, b, c);
-  addTriangle(triangles, a, c, d);
 }
 
 function signedArea(points: Point2D[]): number {

--- a/src/text/mesh.ts
+++ b/src/text/mesh.ts
@@ -5,6 +5,7 @@ import type { Point2D } from '../types/geometry.js';
 import type { Rect2D } from '../types/text.js';
 import { buildContourTree, collectShapes, translateAndScaleContours, translateAndScaleBounds } from './contours.js';
 import type { ContourShape } from './contours.js';
+import { isDegenerateTriangle } from '../model/mesh-primitives.js';
 
 export const TEXT_HEIGHT_MM = 0.8;
 export const DEFAULT_TEXT_POSITION_RANK = 1;
@@ -23,6 +24,9 @@ function createVertex(x: number, y: number, z: number): Vertex {
 }
 
 function addTriangle(triangles: Triangle[], a: Vertex, b: Vertex, c: Vertex): void {
+  if (isDegenerateTriangle(a, b, c)) {
+    return;
+  }
   triangles.push([a, b, c]);
 }
 

--- a/test/mesh-primitives.test.ts
+++ b/test/mesh-primitives.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { addTriangle, isDegenerateTriangle } from '../src/model/mesh-primitives.js';
+import type { Triangle, Vertex } from '../src/types/model.js';
+
+const v = (x: number, y: number, z: number): Vertex => ({ x, y, z });
+
+test('isDegenerateTriangle flags triangles whose vertices coincide on the export grid', () => {
+  // Two vertices identical.
+  assert.equal(isDegenerateTriangle(v(0, 0, 0), v(0, 0, 0), v(1, 0, 0)), true);
+  // Distinct in full precision but collapsing under the 1e-4 mm dedup.
+  assert.equal(isDegenerateTriangle(v(0, 0, 0), v(0, 0, 1e-6), v(1, 0, 0)), true);
+});
+
+test('isDegenerateTriangle keeps thin, collinear-but-distinct slivers', () => {
+  // Three collinear yet separate vertices (zero area). These must NOT be
+  // dropped: an area-based filter would remove them and open holes in the
+  // ribbon/pocket meshes, since the sliver still carries edge-pairing. This
+  // guards against regressing the STL hole bug.
+  assert.equal(isDegenerateTriangle(v(0, 0, 0), v(0.5, 0, 0), v(1, 0, 0)), false);
+  // A genuinely thin but non-collinear sliver is also kept.
+  assert.equal(isDegenerateTriangle(v(0, 0, 0), v(1, 0, 0), v(0.5, 1e-3, 0)), false);
+});
+
+test('addTriangle drops only coincident-vertex triangles', () => {
+  const triangles: Triangle[] = [];
+  addTriangle(triangles, v(0, 0, 0), v(0, 0, 0), v(1, 0, 0)); // coincident → dropped
+  addTriangle(triangles, v(0, 0, 0), v(0.5, 0, 0), v(1, 0, 0)); // collinear → kept
+  addTriangle(triangles, v(0, 0, 0), v(1, 0, 0), v(0, 1, 0)); // real → kept
+  assert.equal(triangles.length, 2);
+});

--- a/test/threemf-manifold-spa.test.ts
+++ b/test/threemf-manifold-spa.test.ts
@@ -3,6 +3,10 @@
  * synthetic loops in threemf-manifold.test.ts don't trigger the
  * earcut-with-many-baseline-collinear-glyph-holes failure mode that
  * shows up on real tracks with long printed labels.
+ *
+ * As in threemf-manifold.test.ts, `validate-mesh` measures the mesh at the
+ * exporter's own 1e-4 mm grid, so passing here means manifold *at that grid*,
+ * not necessarily manifold under a slicer's stricter quantization.
  */
 
 import assert from 'node:assert/strict';

--- a/test/threemf-manifold-spa.test.ts
+++ b/test/threemf-manifold-spa.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression test against real Spa-Francorchamps OSM geometry — the
+ * synthetic loops in threemf-manifold.test.ts don't trigger the
+ * earcut-with-many-baseline-collinear-glyph-holes failure mode that
+ * shows up on real tracks with long printed labels.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { buildBasePlate, buildTrackOutline } from '../src/geometry/outline.js';
+import { projectNodes } from '../src/geometry/projection.js';
+import { buildTrackModel } from '../src/model/index.js';
+import { splitModelTriangles } from '../src/model/triangle-groups.js';
+import { findNonManifoldEdges, summarizeMesh } from '../src/model/validate-mesh.js';
+import type { Triangle } from '../src/types/model.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const spaPath = join(here, '..', 'src', 'generated', 'geometry', 'Q172851.json');
+type TrackFile = {
+  center: { lat: number; lon: number };
+  layouts: Array<{ id: string; name: string; nodes: Array<{ lat: number; lon: number }> }>;
+};
+const spa: TrackFile = JSON.parse(readFileSync(spaPath, 'utf8'));
+
+function assertPartManifold(label: string, triangles: Triangle[]): void {
+  if (triangles.length === 0) { return; }
+  const nm = findNonManifoldEdges(triangles);
+  if (nm.length > 0) {
+    const summary = summarizeMesh(triangles);
+    const examples = nm.slice(0, 3).map(e => ({
+      a: { x: +e.a.x.toFixed(4), y: +e.a.y.toFixed(4), z: +e.a.z.toFixed(4) },
+      b: { x: +e.b.x.toFixed(4), y: +e.b.y.toFixed(4), z: +e.b.z.toFixed(4) },
+      triangleIndices: e.triangleIndices,
+    }));
+    assert.fail(`${label}: ${nm.length} non-manifold edges\n  summary=${JSON.stringify(summary)}\n  first: ${JSON.stringify(examples)}`);
+  }
+}
+
+test('Spa-Francorchamps flush coaster — each 3MF object is 2-manifold', () => {
+  const layout = spa.layouts.find(l => l.id === 'grand-prix') ?? spa.layouts[0]!;
+  const projected = projectNodes(layout.nodes, null, spa.center);
+  const outlinePoints = buildTrackOutline(projected, 12);
+  const basePlate = buildBasePlate(outlinePoints, 50);
+  const model = buildTrackModel({
+    outlinePoints,
+    basePlate,
+    projectedNodes: projected,
+    trackName: 'Spa-Francorchamps Circuit',
+    coasterMode: true,
+    coasterShape: 'round',
+    coasterInlay: 'flush',
+    primaryOrientationDeg: 'auto',
+  });
+  const { baseTriangles, secondaryTrackTriangles, trackTriangles } = splitModelTriangles(model);
+  assertPartManifold('Spa flush / base', baseTriangles);
+  assertPartManifold('Spa flush / secondary', secondaryTrackTriangles);
+  assertPartManifold('Spa flush / track + text', trackTriangles);
+});

--- a/test/threemf-manifold.test.ts
+++ b/test/threemf-manifold.test.ts
@@ -1,3 +1,13 @@
+/**
+ * Per-part 2-manifold assertions for the exported mesh.
+ *
+ * Caveat: `validate-mesh` quantizes on the same 1e-4 mm grid the 3MF exporter
+ * uses, so these tests verify the mesh is self-consistent *at the export grid*
+ * — they cannot detect non-manifold edges a slicer with a tighter or different
+ * grid (e.g. Bambu Studio) might still report. The flush-coaster-with-text case
+ * is one such known residual, tracked in the PR; a green run here is necessary
+ * but not sufficient for "clean in the slicer".
+ */
 import assert from 'node:assert/strict';
 import test from 'node:test';
 

--- a/test/threemf-manifold.test.ts
+++ b/test/threemf-manifold.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildBasePlate, buildTrackOutline } from '../src/geometry/outline.js';
+import { buildTrackModel } from '../src/model/index.js';
+import { splitModelTriangles } from '../src/model/triangle-groups.js';
+import { findDegenerateTriangles, findNonManifoldEdges, summarizeMesh } from '../src/model/validate-mesh.js';
+import type { ProjectedNode } from '../src/types/geometry.js';
+import type { Triangle } from '../src/types/model.js';
+
+/**
+ * A simple closed racing-line: rounded rectangle in projected metres.
+ * Enough nodes to give the ribbon a real curvature without producing
+ * pathological sharp angles.
+ */
+function syntheticProjectedLoop(): ProjectedNode[] {
+  const cx = 0, cy = 0;
+  const halfW = 80;
+  const halfH = 50;
+  const radius = 25;
+  const segmentsPerCorner = 6;
+  const nodes: ProjectedNode[] = [];
+
+  function pushArc(centerX: number, centerY: number, startDeg: number, endDeg: number): void {
+    for (let i = 1; i <= segmentsPerCorner; i += 1) {
+      const t = i / segmentsPerCorner;
+      const angle = ((startDeg + (endDeg - startDeg) * t) * Math.PI) / 180;
+      nodes.push({ x: centerX + Math.cos(angle) * radius, y: centerY + Math.sin(angle) * radius, elevation: 0 });
+    }
+  }
+
+  nodes.push({ x: cx - halfW + radius, y: cy - halfH, elevation: 0 });
+  nodes.push({ x: cx + halfW - radius, y: cy - halfH, elevation: 0 });
+  pushArc(cx + halfW - radius, cy - halfH + radius, -90, 0);
+  nodes.push({ x: cx + halfW, y: cy + halfH - radius, elevation: 0 });
+  pushArc(cx + halfW - radius, cy + halfH - radius, 0, 90);
+  nodes.push({ x: cx - halfW + radius, y: cy + halfH, elevation: 0 });
+  pushArc(cx - halfW + radius, cy + halfH - radius, 90, 180);
+  nodes.push({ x: cx - halfW, y: cy - halfH + radius, elevation: 0 });
+  pushArc(cx - halfW + radius, cy - halfH + radius, 180, 270);
+  return nodes;
+}
+
+function buildModelForCase(opts: {
+  coasterMode?: boolean;
+  coasterInlay?: 'flush' | 'raised';
+  trackName?: string;
+}) {
+  const projectedNodes = syntheticProjectedLoop();
+  const outlinePoints = buildTrackOutline(projectedNodes, 12);
+  const basePlate = buildBasePlate(outlinePoints, 50);
+  return buildTrackModel({
+    outlinePoints,
+    basePlate,
+    projectedNodes,
+    trackName: opts.trackName ?? 'Test Loop',
+    coasterMode: opts.coasterMode ?? false,
+    coasterShape: 'round',
+    ...(opts.coasterInlay ? { coasterInlay: opts.coasterInlay } : {}),
+    primaryOrientationDeg: 0,
+  });
+}
+
+function assertPartManifold(label: string, triangles: Triangle[]): void {
+  if (triangles.length === 0) {
+    return;
+  }
+  const nonManifold = findNonManifoldEdges(triangles);
+  const degenerate = findDegenerateTriangles(triangles);
+  if (nonManifold.length > 0 || degenerate.length > 0) {
+    const summary = summarizeMesh(triangles);
+    const examples = nonManifold.slice(0, 5).map(e => ({
+      a: { x: +e.a.x.toFixed(4), y: +e.a.y.toFixed(4), z: +e.a.z.toFixed(4) },
+      b: { x: +e.b.x.toFixed(4), y: +e.b.y.toFixed(4), z: +e.b.z.toFixed(4) },
+      triangleIndices: e.triangleIndices,
+    }));
+    assert.fail(
+      `${label}: part is not 2-manifold\n  summary=${JSON.stringify(summary)}\n  first non-manifold edges: ${JSON.stringify(examples, null, 2)}\n  degenerate triangle indices (first 5): ${JSON.stringify(degenerate.slice(0, 5))}`,
+    );
+  }
+}
+
+/**
+ * Validates that each logical part of the model — base, secondary tracks,
+ * primary track + text — is independently 2-manifold. This mirrors what
+ * Bambu sees, since `build3mfModelXml` emits one `<object>` per part with
+ * its own vertex pool.
+ */
+function assertModelManifold(label: string, model: ReturnType<typeof buildTrackModel>): void {
+  const { baseTriangles, secondaryTrackTriangles, trackTriangles } = splitModelTriangles(model);
+  assertPartManifold(`${label} / base`, baseTriangles);
+  assertPartManifold(`${label} / secondary tracks`, secondaryTrackTriangles);
+  assertPartManifold(`${label} / primary track + text`, trackTriangles);
+}
+
+test('non-coaster export is 2-manifold per part', () => {
+  const model = buildModelForCase({ coasterMode: false });
+  assertModelManifold('non-coaster', model);
+});
+
+test('coaster round + raised export is 2-manifold per part (Spa repro mode)', () => {
+  const model = buildModelForCase({ coasterMode: true, coasterInlay: 'raised' });
+  assertModelManifold('coaster raised', model);
+});
+
+test('coaster round + flush export is 2-manifold per part', () => {
+  const model = buildModelForCase({ coasterMode: true, coasterInlay: 'flush' });
+  assertModelManifold('coaster flush', model);
+});


### PR DESCRIPTION
## Summary

Bambu Studio was reporting many non-manifold edges when importing 3MF files exported by this app — most prominently in coaster flush mode on Spa-Francorchamps. The print worked fine, but the warning was real and persistent. This PR fixes the majority of cases and gets the synthetic + real-Spa per-part manifold tests to pass; one residual case is documented at the end.

Closes #107.

## The problem

`buildTrackModel` stitches several independently-watertight sub-meshes — base plate, primary ribbon, secondary ribbons, text glyphs — into a single triangle list that `package3mf` then writes into one `<object>`/`<mesh>`, deduping vertices at 4 decimals.

That arrangement broke 2-manifoldness in multiple places:

1. **Buried, coplanar interior faces.** Every ribbon/text bottom face sat at z = 2.5 mm directly on the base plate's top face. Coplanar but with separate vertex pools, so the merged mesh had multiple disjoint shells.
2. **Degenerate triangles.** `buildRoundedRectangleRing` produced a duplicate first/last vertex (the closing arc landed exactly on the first explicit point), giving the base plate a degenerate side-wall quad. `buildRaisedRibbonMesh`'s strict `===` section dedup missed near-duplicate sections at near-collinear corners, producing bow-tie stitch quads.
3. **4 surfaces meeting at one edge** in flush coaster mode: at every pocket-boundary edge, the base top, the pocket wall, the inlay top, and the inlay outer wall all met. Structurally non-2-manifold inside a single mesh.
4. **Earcut producing invalid triangulation** for the flush-mode coaster top with many text pockets sharing collinear baseline vertices — open boundary edges in the output.

## What this PR does

### Diagnostics
- New `src/model/validate-mesh.ts`: `findNonManifoldEdges`, `findDegenerateTriangles`, `summarizeMesh`. Quantizes at the same 1e-4 mm grid the 3MF exporter uses, so it measures the mesh as Bambu sees it.
- New `test/threemf-manifold.test.ts`: per-part 2-manifold assertions for non-coaster, coaster raised, coaster flush.
- New `test/threemf-manifold-spa.test.ts`: per-part 2-manifold assertion using the real Spa-Francorchamps OSM data (the synthetic loop didn't exercise every earcut edge case real data does).

### Multi-object 3MF (the structural fix)
`build3mfModelXml` now emits one `<object>` per logical part — base plate, secondary tracks, primary track + text — each with its own vertex pool. Bambu validates each object independently, so coplanar pocket walls in different parts no longer produce 4-incident edges in a shared mesh. Each object still references the shared `<m:colorgroup>`; per-triangle `p1` color attributes are preserved so existing color-group tests still pass.

### Geometry fixes
- `src/model/base-plate.ts`: `buildRoundedRectangleRing` pops the duplicate closing vertex. `buildCoasterBasePlateMesh` applies a `simplifyRing` pass to pocket boundaries and islands to drop colinear/collapsing vertices before earcut.
- `src/model/mesh-primitives.ts`: shared `addTriangle` skips triangles whose two vertices collapse under 1e-4 mm dedup. Same filter wired into `src/text/mesh.ts addTriangle`.
- `src/model/track-ribbon.ts`: section dedup uses a 1.5e-4 mm epsilon (was strict ===) so near-duplicate sections at gentle corners no longer generate degenerate stitch quads.
- `src/export/threemf.ts` and `src/export/stl.ts`: defence-in-depth filter drops triangles that collapse after vertex dedup.

### Flush-mode text pocket perturbation (workaround for an earcut limitation)
Earcut fails to produce a valid triangulation for the coaster top when many text-pocket holes share the same baseline (e.g. several letters of "Spa-Francorchamps Circuit" all having vertices at y = baseline). The output has open boundary edges between glyphs.

`src/model/track-model.ts` now applies a unique `(dx, dy)` offset of `(glyphIndex + 1) × 5e-4 mm` to each text pocket contour before passing it to `buildCoasterBasePlateMesh`. The perturbation is well above the 1e-4 mm export quantization grid (so vertices stay distinct after dedup) and well below printer resolution (~0.05 mm) — invisible in the print, but enough to break collinearity and let earcut produce a valid triangulation.

## Test results

- `test/threemf-manifold.test.ts` — 3/3 pass: non-coaster, coaster raised, coaster flush.
- `test/threemf-manifold-spa.test.ts` — passes against real Spa OSM data.
- Full suite: 167 tests, 0 failures.

## Known residual issue

User reports that **flush coaster + text** still shows non-manifold edges in Bambu Studio (down significantly from before, but not zero). Without text, both my validator and Bambu agree the export is clean. With text, my validator reports clean but Bambu still flags some.

Hypotheses worth investigating:

- **Bambu's quantization differs from the 1e-4 mm grid I'm matching.** If Bambu rounds tighter, the per-glyph perturbation may be too small to keep vertices distinct after their dedup, and pairs of glyphs could collapse to collinear again. Worth experimenting with a larger perturbation (1e-3 to 5e-3 mm).
- **Glyph contours self-intersect** after the perturbation when the perturbation magnitude approaches the glyph's own feature size. Worth verifying the perturbed contours still pass a self-intersection check.
- **The perturbation only varies in (x, y) but glyphs share a z plane.** A perturbation that tilts each glyph slightly (offsetting top vs floor differently) could break a different class of collinearity at the pocket-wall top edges.

Possible alternative approaches if the perturbation hack doesn't fully close the gap:

- **Switch the coaster-top triangulator** to something more robust than earcut (poly2tri, or a CDT library). Earcut is fast but not the right tool for many-hole inputs with shared collinear vertices.
- **Pre-compute the coaster top via turf.difference** as `coaster_disc − union(pockets)`. Turf's polygon-clipping handles colinear/touching boundaries more rigorously than earcut's hole bridging.
- **Drop text pockets from the base plate entirely** in flush mode and emit the text mesh as a Bambu modifier object. The text becomes a closed prism that overlaps the coaster volume; Bambu paints the overlap with the modifier's colour. Topologically clean (each object is its own watertight mesh), but visually depends on Bambu's modifier behaviour and may need testing.

## Test plan

- [x] `npm test` passes (167/167).
- [x] Spa-Francorchamps non-coaster export — Bambu reports clean.
- [x] Spa-Francorchamps coaster raised export — Bambu reports clean.
- [x] Spa-Francorchamps coaster flush, no text — Bambu reports clean.
- [ ] Spa-Francorchamps coaster flush with text — Bambu still reports a small number of non-manifold edges (down from 4286 → ~3 in the user's repro). Print works; warning persists. Tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)