### PR TITLE
refactor: consolidate mesh validation into validateModel() + shared test helper (#121)

### DIFF
--- a/src/model/validate-mesh.ts
+++ b/src/model/validate-mesh.ts
@@ -8,7 +8,8 @@
  * validator measures the mesh as Bambu Studio sees it after vertex dedup.
  */
 
-import type { Triangle, Vertex } from '../types/model.js';
+import type { Triangle, TrackModel, Vertex } from '../types/model.js';
+import { splitModelTriangles } from './triangle-groups.js';
 
 /** 4-decimal quantization, matching `formatCoordinate` in src/export/threemf.ts. */
 const DEFAULT_PRECISION_MM = 1e-4;
@@ -138,4 +139,60 @@ export function summarizeMesh(triangles: Triangle[], options: ValidateOptions = 
     nonManifoldEdgeCount: findNonManifoldEdges(triangles, options).length,
     degenerateTriangleCount: findDegenerateTriangles(triangles, options).length,
   };
+}
+
+export interface PartReport {
+  /** Logical part name. 'track' = primary track + embossed text (same exported object). */
+  part: 'base' | 'secondary' | 'track';
+  triangleCount: number;
+  nonManifoldEdges: NonManifoldEdge[];
+  degenerateTriangles: number[];
+  // Extended as #109 / #115 land — additive only, never removing the above:
+  // tJunctions: TJunction[];
+  // flippedFaces: number[];
+  // selfIntersections: SelfIntersection[];
+  // shellComponents: number;
+}
+
+export interface ModelReport {
+  /** True iff every part is 2-manifold AND free of degenerate triangles. Pure data report; the
+   *  decision of what to ASSERT on lives in the test helper's `failOn`, not here. */
+  ok: boolean;
+  parts: PartReport[];
+}
+
+/**
+ * Splits a model into its per-part triangle groups (base / secondary / track)
+ * and composes the existing manifold + degenerate detectors into a structured
+ * report. Pure data: it always computes both detectors for every part and never
+ * decides what callers should fail on — that decision lives in the test helper.
+ *
+ * `parts` always contains exactly three entries in the fixed order
+ * `base`, `secondary`, `track`; empty parts are included with zero findings and
+ * therefore never make `ok` false.
+ */
+export function validateModel(
+  model: TrackModel,
+  options: ValidateOptions = {},
+): ModelReport {
+  const { baseTriangles, secondaryTrackTriangles, trackTriangles } = splitModelTriangles(model);
+
+  const buildPart = (part: PartReport['part'], triangles: Triangle[]): PartReport => ({
+    part,
+    triangleCount: triangles.length,
+    nonManifoldEdges: findNonManifoldEdges(triangles, options),
+    degenerateTriangles: findDegenerateTriangles(triangles, options),
+  });
+
+  const parts: PartReport[] = [
+    buildPart('base', baseTriangles),
+    buildPart('secondary', secondaryTrackTriangles),
+    buildPart('track', trackTriangles),
+  ];
+
+  const ok = parts.every(
+    p => p.nonManifoldEdges.length === 0 && p.degenerateTriangles.length === 0,
+  );
+
+  return { ok, parts };
 }

--- a/test-utils/mesh-assertions.ts
+++ b/test-utils/mesh-assertions.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+
+import { summarizeMesh, validateModel } from '../src/model/validate-mesh.js';
+import type { PartReport, ValidateOptions } from '../src/model/validate-mesh.js';
+import { splitModelTriangles } from '../src/model/triangle-groups.js';
+import type { Triangle, TrackModel } from '../src/types/model.js';
+
+/** Human-readable per-part label suffix, matching the original test helpers. */
+const PART_LABELS: Record<PartReport['part'], string> = {
+  base: 'base',
+  secondary: 'secondary tracks',
+  track: 'primary track + text',
+};
+
+/**
+ * Asserts that each non-empty part of the model is 2-manifold (and, depending on
+ * `failOn`, free of degenerate triangles). Composes `validateModel`, which mirrors
+ * what Bambu sees — `build3mfModelXml` emits one `<object>` per part with its own
+ * vertex pool.
+ *
+ * `failOn` selects the failure CONDITION:
+ *   - `'edges+degenerates'` (default): fail on non-manifold edges OR degenerate triangles.
+ *   - `'edges'`: fail ONLY on non-manifold edges.
+ *
+ * Degenerate diagnostics are PRINTED in the failure message in both modes; printing
+ * is not failing.
+ */
+export function assertModelManifold(
+  label: string,
+  model: TrackModel,
+  options?: { failOn?: 'edges' | 'edges+degenerates' } & ValidateOptions,
+): void {
+  const { failOn = 'edges+degenerates', ...validateOptions } = options ?? {};
+  const report = validateModel(model, validateOptions);
+  const groups = splitModelTriangles(model);
+  const trianglesByPart: Record<PartReport['part'], Triangle[]> = {
+    base: groups.baseTriangles,
+    secondary: groups.secondaryTrackTriangles,
+    track: groups.trackTriangles,
+  };
+
+  for (const part of report.parts) {
+    if (part.triangleCount === 0) {
+      continue;
+    }
+
+    const failed =
+      part.nonManifoldEdges.length > 0 ||
+      (failOn === 'edges+degenerates' && part.degenerateTriangles.length > 0);
+
+    if (!failed) {
+      continue;
+    }
+
+    const partLabel = `${label} / ${PART_LABELS[part.part]}`;
+    const summary = summarizeMesh(trianglesByPart[part.part], validateOptions);
+    const examples = part.nonManifoldEdges.slice(0, 5).map(e => ({
+      a: { x: +e.a.x.toFixed(4), y: +e.a.y.toFixed(4), z: +e.a.z.toFixed(4) },
+      b: { x: +e.b.x.toFixed(4), y: +e.b.y.toFixed(4), z: +e.b.z.toFixed(4) },
+      triangleIndices: e.triangleIndices,
+    }));
+    assert.fail(
+      `${partLabel}: part is not 2-manifold\n  summary=${JSON.stringify(summary)}\n  first non-manifold edges: ${JSON.stringify(examples, null, 2)}\n  degenerate triangle indices (first 5): ${JSON.stringify(part.degenerateTriangles.slice(0, 5))}`,
+    );
+  }
+}

--- a/test/threemf-manifold-spa.test.ts
+++ b/test/threemf-manifold-spa.test.ts
@@ -9,7 +9,6 @@
  * not necessarily manifold under a slicer's stricter quantization.
  */
 
-import assert from 'node:assert/strict';
 import test from 'node:test';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -18,9 +17,7 @@ import { dirname, join } from 'node:path';
 import { buildBasePlate, buildTrackOutline } from '../src/geometry/outline.js';
 import { projectNodes } from '../src/geometry/projection.js';
 import { buildTrackModel } from '../src/model/index.js';
-import { splitModelTriangles } from '../src/model/triangle-groups.js';
-import { findNonManifoldEdges, summarizeMesh } from '../src/model/validate-mesh.js';
-import type { Triangle } from '../src/types/model.js';
+import { assertModelManifold } from '../test-utils/mesh-assertions.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const spaPath = join(here, '..', 'src', 'generated', 'geometry', 'Q172851.json');
@@ -29,20 +26,6 @@ type TrackFile = {
   layouts: Array<{ id: string; name: string; nodes: Array<{ lat: number; lon: number }> }>;
 };
 const spa: TrackFile = JSON.parse(readFileSync(spaPath, 'utf8'));
-
-function assertPartManifold(label: string, triangles: Triangle[]): void {
-  if (triangles.length === 0) { return; }
-  const nm = findNonManifoldEdges(triangles);
-  if (nm.length > 0) {
-    const summary = summarizeMesh(triangles);
-    const examples = nm.slice(0, 3).map(e => ({
-      a: { x: +e.a.x.toFixed(4), y: +e.a.y.toFixed(4), z: +e.a.z.toFixed(4) },
-      b: { x: +e.b.x.toFixed(4), y: +e.b.y.toFixed(4), z: +e.b.z.toFixed(4) },
-      triangleIndices: e.triangleIndices,
-    }));
-    assert.fail(`${label}: ${nm.length} non-manifold edges\n  summary=${JSON.stringify(summary)}\n  first: ${JSON.stringify(examples)}`);
-  }
-}
 
 test('Spa-Francorchamps flush coaster — each 3MF object is 2-manifold', () => {
   const layout = spa.layouts.find(l => l.id === 'grand-prix') ?? spa.layouts[0]!;
@@ -59,8 +42,5 @@ test('Spa-Francorchamps flush coaster — each 3MF object is 2-manifold', () => 
     coasterInlay: 'flush',
     primaryOrientationDeg: 'auto',
   });
-  const { baseTriangles, secondaryTrackTriangles, trackTriangles } = splitModelTriangles(model);
-  assertPartManifold('Spa flush / base', baseTriangles);
-  assertPartManifold('Spa flush / secondary', secondaryTrackTriangles);
-  assertPartManifold('Spa flush / track + text', trackTriangles);
+  assertModelManifold('Spa flush', model, { failOn: 'edges' });
 });

--- a/test/threemf-manifold.test.ts
+++ b/test/threemf-manifold.test.ts
@@ -8,15 +8,12 @@
  * is one such known residual, tracked in the PR; a green run here is necessary
  * but not sufficient for "clean in the slicer".
  */
-import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { buildBasePlate, buildTrackOutline } from '../src/geometry/outline.js';
 import { buildTrackModel } from '../src/model/index.js';
-import { splitModelTriangles } from '../src/model/triangle-groups.js';
-import { findDegenerateTriangles, findNonManifoldEdges, summarizeMesh } from '../src/model/validate-mesh.js';
+import { assertModelManifold } from '../test-utils/mesh-assertions.js';
 import type { ProjectedNode } from '../src/types/geometry.js';
-import type { Triangle } from '../src/types/model.js';
 
 /**
  * A simple closed racing-line: rounded rectangle in projected metres.
@@ -69,38 +66,6 @@ function buildModelForCase(opts: {
     ...(opts.coasterInlay ? { coasterInlay: opts.coasterInlay } : {}),
     primaryOrientationDeg: 0,
   });
-}
-
-function assertPartManifold(label: string, triangles: Triangle[]): void {
-  if (triangles.length === 0) {
-    return;
-  }
-  const nonManifold = findNonManifoldEdges(triangles);
-  const degenerate = findDegenerateTriangles(triangles);
-  if (nonManifold.length > 0 || degenerate.length > 0) {
-    const summary = summarizeMesh(triangles);
-    const examples = nonManifold.slice(0, 5).map(e => ({
-      a: { x: +e.a.x.toFixed(4), y: +e.a.y.toFixed(4), z: +e.a.z.toFixed(4) },
-      b: { x: +e.b.x.toFixed(4), y: +e.b.y.toFixed(4), z: +e.b.z.toFixed(4) },
-      triangleIndices: e.triangleIndices,
-    }));
-    assert.fail(
-      `${label}: part is not 2-manifold\n  summary=${JSON.stringify(summary)}\n  first non-manifold edges: ${JSON.stringify(examples, null, 2)}\n  degenerate triangle indices (first 5): ${JSON.stringify(degenerate.slice(0, 5))}`,
-    );
-  }
-}
-
-/**
- * Validates that each logical part of the model — base, secondary tracks,
- * primary track + text — is independently 2-manifold. This mirrors what
- * Bambu sees, since `build3mfModelXml` emits one `<object>` per part with
- * its own vertex pool.
- */
-function assertModelManifold(label: string, model: ReturnType<typeof buildTrackModel>): void {
-  const { baseTriangles, secondaryTrackTriangles, trackTriangles } = splitModelTriangles(model);
-  assertPartManifold(`${label} / base`, baseTriangles);
-  assertPartManifold(`${label} / secondary tracks`, secondaryTrackTriangles);
-  assertPartManifold(`${label} / primary track + text`, trackTriangles);
 }
 
 test('non-coaster export is 2-manifold per part', () => {

--- a/test/validate-model.test.ts
+++ b/test/validate-model.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Structural contract test for `validateModel`: locks the part ordering,
+ * empty-part inclusion, and `ok` derivation so future #109/#115 extensions
+ * don't silently change the report shape.
+ */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildBasePlate, buildTrackOutline } from '../src/geometry/outline.js';
+import { buildTrackModel } from '../src/model/index.js';
+import { validateModel } from '../src/model/validate-mesh.js';
+import type { ProjectedNode } from '../src/types/geometry.js';
+
+function syntheticProjectedLoop(): ProjectedNode[] {
+  const halfW = 80;
+  const halfH = 50;
+  const radius = 25;
+  const segmentsPerCorner = 6;
+  const nodes: ProjectedNode[] = [];
+
+  function pushArc(centerX: number, centerY: number, startDeg: number, endDeg: number): void {
+    for (let i = 1; i <= segmentsPerCorner; i += 1) {
+      const t = i / segmentsPerCorner;
+      const angle = ((startDeg + (endDeg - startDeg) * t) * Math.PI) / 180;
+      nodes.push({ x: centerX + Math.cos(angle) * radius, y: centerY + Math.sin(angle) * radius, elevation: 0 });
+    }
+  }
+
+  nodes.push({ x: -halfW + radius, y: -halfH, elevation: 0 });
+  nodes.push({ x: halfW - radius, y: -halfH, elevation: 0 });
+  pushArc(halfW - radius, -halfH + radius, -90, 0);
+  nodes.push({ x: halfW, y: halfH - radius, elevation: 0 });
+  pushArc(halfW - radius, halfH - radius, 0, 90);
+  nodes.push({ x: -halfW + radius, y: halfH, elevation: 0 });
+  pushArc(-halfW + radius, halfH - radius, 90, 180);
+  nodes.push({ x: -halfW, y: -halfH + radius, elevation: 0 });
+  pushArc(-halfW + radius, -halfH + radius, 180, 270);
+  return nodes;
+}
+
+function buildModel() {
+  const projectedNodes = syntheticProjectedLoop();
+  const outlinePoints = buildTrackOutline(projectedNodes, 12);
+  const basePlate = buildBasePlate(outlinePoints, 50);
+  return buildTrackModel({
+    outlinePoints,
+    basePlate,
+    projectedNodes,
+    trackName: 'Test Loop',
+    coasterMode: false,
+    coasterShape: 'round',
+    primaryOrientationDeg: 0,
+  });
+}
+
+test('validateModel reports parts in fixed base/secondary/track order', () => {
+  const report = validateModel(buildModel());
+  assert.deepEqual(report.parts.map(p => p.part), ['base', 'secondary', 'track']);
+});
+
+test('validateModel includes empty parts with zero findings that never break ok', () => {
+  const report = validateModel(buildModel());
+  // The synthetic non-coaster model has no secondary track.
+  const secondary = report.parts.find(p => p.part === 'secondary')!;
+  assert.equal(secondary.triangleCount, 0);
+  assert.deepEqual(secondary.nonManifoldEdges, []);
+  assert.deepEqual(secondary.degenerateTriangles, []);
+});
+
+test('validateModel.ok is true iff every part has zero non-manifold edges and degenerates', () => {
+  const report = validateModel(buildModel());
+  const expected = report.parts.every(
+    p => p.nonManifoldEdges.length === 0 && p.degenerateTriangles.length === 0,
+  );
+  assert.equal(report.ok, expected);
+  assert.equal(report.ok, true);
+});


### PR DESCRIPTION
## Summary

Pure refactor (no behaviour change) consolidating the duplicated per-part mesh validation logic into a single entry point plus one shared test helper.

- **`src/model/validate-mesh.ts`**: adds `validateModel(model, options?)`, `PartReport`, and `ModelReport`. `validateModel` splits a `TrackModel` into base/secondary/track triangle groups via the existing `splitModelTriangles` and composes the existing `findNonManifoldEdges` / `findDegenerateTriangles` detectors. `parts[]` is always `['base','secondary','track']` (empty parts included with zero findings); `ModelReport.ok` is a pure data value (true iff every part has zero non-manifold edges and zero degenerate triangles). `PartReport` is additively extensible for future #109/#115 fields (commented placeholders only). Existing exports and detector implementations are unchanged.
- **`test-utils/mesh-assertions.ts`** (new): shared `assertModelManifold(label, model, options?)`. Its `failOn` parameter (`'edges'` | `'edges+degenerates'`, default `'edges+degenerates'`) selects the failure condition; degenerate diagnostics are printed in both modes (printing is not failing). Empty parts are skipped.
- **`test/threemf-manifold.test.ts`** / **`test/threemf-manifold-spa.test.ts`**: local `assertPartManifold` helpers removed and replaced with the shared helper — manifold test uses the default (edges OR degenerates), SPA test passes `failOn: 'edges'` (edges only). Now-unused imports removed.
- **`test/validate-model.test.ts`** (new, optional per plan): locks part ordering, empty-part inclusion, and `ok` derivation.

## Why

Removes two near-identical `assertPartManifold` helpers and centralises the model→parts→detectors composition behind a single reusable API, so the upcoming #109/#115 detectors can extend `PartReport` additively without touching call sites. Each test keeps its exact current failure condition via `failOn`.

## Plan

Implemented per the approved plan at `.claude/plans/issue-121.md` (intentionally not committed).

## Verification

- `npm run typecheck` — passes.
- `npm test` — 173/173 pass (including refactored manifold/SPA tests and new `validate-model` tests).
- `npm run build` — passes.
- `npm run check:file-sizes` — passes (warnings only).
- `npm run lint` on the changed files — clean. NOTE: `npm run lint` over the whole repo reports 36 pre-existing errors in unrelated files (`src/text/placement.ts`, `src/model/track-model.ts`, etc.); these already fail on `main` (commit 51d6ed3) and are out of scope for this pure refactor. CI runs `npm run build`, which is green.

Closes #121