### PR TITLE
fix: resolve all ESLint errors and warnings (0/0)

### DIFF
--- a/scripts/build-track-search-index.ts
+++ b/scripts/build-track-search-index.ts
@@ -13,6 +13,46 @@ const TRACK_INSTANCE_IDS: Record<string, string> = {
 };
 const ENTITY_BATCH_SIZE = 50;
 
+interface SparqlBinding {
+  item?: { value: string };
+  type?: { value: string };
+  lat?: { value: string };
+  lon?: { value: string };
+}
+
+interface MergedTrackRow {
+  wikidataId: string;
+  type: string | null;
+  lat: number;
+  lon: number;
+  countryId: string | null;
+  cityIds: string[];
+}
+
+interface EntityDetail {
+  label: string | null;
+  aliases: string[];
+  description: string | null;
+  wikidataShortName: string | null;
+  countryId: string | null;
+  cityIds: string[];
+}
+
+interface WikidataClaim {
+  mainsnak?: { datavalue?: { value?: { text?: string; id?: string } } };
+}
+
+interface WikidataAlias {
+  value: string;
+}
+
+interface WikidataEntity {
+  labels?: { en?: { value: string } };
+  aliases?: { en?: WikidataAlias[] };
+  descriptions?: { en?: { value: string } };
+  claims?: Record<string, WikidataClaim[]>;
+}
+
 // Per-track alias supplements. Keys are Wikidata IDs; values are arrays of
 // additional alias strings to merge with the Wikidata-sourced aliases.
 // Use this for well-known names absent from Wikidata (e.g. branding names or
@@ -30,7 +70,7 @@ function extractWikidataId(value: unknown): string | null {
   return String(value ?? '').split('/').pop()! || null;
 }
 
-async function fetchJson(url: string, options?: RequestInit, retryOptions?: { retries?: number; baseDelayMs?: number }): Promise<any> {
+async function fetchJson(url: string, options?: RequestInit, retryOptions?: { retries?: number; baseDelayMs?: number }): Promise<unknown> {
   const { retries = 4, baseDelayMs = 1000 } = retryOptions ?? {};
   const { headers: optionHeaders, ...restOptions } = options ?? {};
 
@@ -59,9 +99,9 @@ async function fetchJson(url: string, options?: RequestInit, retryOptions?: { re
   }
 }
 
-async function fetchTrackRows(): Promise<any[]> {
+async function fetchTrackRows(): Promise<SparqlBinding[]> {
   const pageSize = 500;
-  const rows: any[] = [];
+  const rows: SparqlBinding[] = [];
 
   for (let offset = 0; ; offset += pageSize) {
     const sparql = `
@@ -85,7 +125,7 @@ OFFSET ${offset}
         'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
       },
       body: `query=${encodeURIComponent(sparql)}&format=json`,
-    });
+    }) as { results?: { bindings?: SparqlBinding[] } };
 
     const pageRows = payload.results?.bindings ?? [];
     rows.push(...pageRows);
@@ -95,8 +135,8 @@ OFFSET ${offset}
   }
 }
 
-function mergeTrackRows(rows: any[]) {
-  const merged = new Map<string, any>();
+function mergeTrackRows(rows: SparqlBinding[]) {
+  const merged = new Map<string, MergedTrackRow>();
 
   for (const row of rows) {
     const wikidataId = extractWikidataId(row.item?.value);
@@ -107,8 +147,8 @@ function mergeTrackRows(rows: any[]) {
     const existing = merged.get(wikidataId) ?? {
       wikidataId,
       type: TRACK_INSTANCE_IDS[extractWikidataId(row.type?.value)!] ?? null,
-      lat: Number.parseFloat(row.lat?.value),
-      lon: Number.parseFloat(row.lon?.value),
+      lat: Number.parseFloat(row.lat?.value ?? ''),
+      lon: Number.parseFloat(row.lon?.value ?? ''),
       countryId: null,
       cityIds: [],
     };
@@ -120,25 +160,25 @@ function mergeTrackRows(rows: any[]) {
 }
 
 async function fetchEntityDetails(ids: string[]) {
-  const entities = new Map<string, any>();
+  const entities = new Map<string, EntityDetail>();
 
   for (let index = 0; index < ids.length; index += ENTITY_BATCH_SIZE) {
     const batch = ids.slice(index, index + ENTITY_BATCH_SIZE);
     const url = `${WIKIDATA_API}?action=wbgetentities&ids=${encodeURIComponent(batch.join('|'))}&languages=en&props=labels|aliases|descriptions|claims&format=json&origin=*`;
-    const payload = await fetchJson(url);
+    const payload = await fetchJson(url) as { entities?: Record<string, WikidataEntity> };
 
     for (const id of batch) {
-      const entity = payload.entities?.[id] ?? {};
+      const entity: WikidataEntity = payload.entities?.[id] ?? {};
       const shortName = entity.claims?.P1813
-        ?.find((claim: any) => claim?.mainsnak?.datavalue?.value?.text)
+        ?.find((claim: WikidataClaim) => claim?.mainsnak?.datavalue?.value?.text)
         ?.mainsnak?.datavalue?.value?.text ?? null;
       const getEntityClaimIds = (property: string): string[] => (entity.claims?.[property] ?? [])
-        .map((claim: any) => claim?.mainsnak?.datavalue?.value?.id)
-        .filter(Boolean);
+        .map((claim: WikidataClaim) => claim?.mainsnak?.datavalue?.value?.id)
+        .filter((value): value is string => Boolean(value));
 
       entities.set(id, {
         label: entity.labels?.en?.value ?? null,
-        aliases: (entity.aliases?.en ?? []).map((alias: any) => alias.value).filter(Boolean),
+        aliases: (entity.aliases?.en ?? []).map((alias: WikidataAlias) => alias.value).filter(Boolean),
         description: entity.descriptions?.en?.value ?? null,
         wikidataShortName: shortName,
         countryId: getEntityClaimIds('P17')[0] ?? null,
@@ -155,10 +195,17 @@ async function fetchEntityDetails(ids: string[]) {
   return entities;
 }
 
-function assembleIndex(baseRows: any[], entityDetails: Map<string, any>) {
+function assembleIndex(baseRows: MergedTrackRow[], entityDetails: Map<string, EntityDetail>) {
   return baseRows
     .map(row => {
-      const details = entityDetails.get(row.wikidataId) ?? {};
+      const details: EntityDetail = entityDetails.get(row.wikidataId) ?? {
+        label: null,
+        aliases: [],
+        description: null,
+        wikidataShortName: null,
+        countryId: null,
+        cityIds: [],
+      };
       const country = details.countryId ? entityDetails.get(details.countryId)?.label ?? null : null;
       const city = (details.cityIds ?? []).map((id: string) => entityDetails.get(id)?.label ?? null).find(Boolean) ?? null;
       const extraAliases = SEARCH_INDEX_ALIASES.get(row.wikidataId) ?? [];

--- a/src/layout-editor/entry.ts
+++ b/src/layout-editor/entry.ts
@@ -70,15 +70,15 @@ function coordsMatch(a: LatLon, b: LatLon): boolean {
 /** Get the effective nodes for a way entry, applying fromNode/toNode slicing. */
 function getEffectiveNodes(entry: EditorWayEntry): LatLon[] {
   const way = wayDataById.get(entry.wayId);
-  if (!way) return [];
+  if (!way) {return [];}
   let nodes = way.nodes;
   if (entry.fromNode) {
     const idx = nodes.findIndex(n => coordsMatch(n, entry.fromNode!));
-    if (idx > 0) nodes = nodes.slice(idx);
+    if (idx > 0) {nodes = nodes.slice(idx);}
   }
   if (entry.toNode) {
     const idx = nodes.findIndex(n => coordsMatch(n, entry.toNode!));
-    if (idx >= 0) nodes = nodes.slice(0, idx + 1);
+    if (idx >= 0) {nodes = nodes.slice(0, idx + 1);}
   }
   return nodes;
 }
@@ -86,7 +86,7 @@ function getEffectiveNodes(entry: EditorWayEntry): LatLon[] {
 /** Find the index of a node in a way's node list. Returns -1 if not found. */
 function findNodeIndex(wayId: number, node: LatLon): number {
   const way = wayDataById.get(wayId);
-  if (!way) return -1;
+  if (!way) {return -1;}
   return way.nodes.findIndex(n => coordsMatch(n, node));
 }
 
@@ -148,7 +148,7 @@ function initMap(): void {
 let searchDebounce: ReturnType<typeof setTimeout> | null = null;
 
 function handleSearchInput(): void {
-  if (searchDebounce) clearTimeout(searchDebounce);
+  if (searchDebounce) {clearTimeout(searchDebounce);}
   searchDebounce = setTimeout(() => {
     const query = searchInput.value.trim();
     if (query.length < 2) {
@@ -254,8 +254,8 @@ async function selectTrack(track: SearchResult): Promise<void> {
           name,
           ways: def.ways.map(w => {
             const entry: EditorWayEntry = { wayId: w.wayId };
-            if (w.fromNode) entry.fromNode = w.fromNode;
-            if (w.toNode) entry.toNode = w.toNode;
+            if (w.fromNode) {entry.fromNode = w.fromNode;}
+            if (w.toNode) {entry.toNode = w.toNode;}
             return entry;
           }),
           collapsed: true,
@@ -277,7 +277,7 @@ async function selectTrack(track: SearchResult): Promise<void> {
 // --- Drawing ---
 
 function clearAll(): void {
-  for (const layer of wayLayers) map.removeLayer(layer);
+  for (const layer of wayLayers) {map.removeLayer(layer);}
   clearTrimMarkers();
   clearLoopPreview();
   wayLayers = [];
@@ -334,10 +334,10 @@ function drawWays(ways: WaysFileWay[]): void {
 function autoTrimPair(entryA: EditorWayEntry, entryB: EditorWayEntry): void {
   const wayA = wayDataById.get(entryA.wayId);
   const wayB = wayDataById.get(entryB.wayId);
-  if (!wayA || !wayB) return;
+  if (!wayA || !wayB) {return;}
 
   const nodesA = getEffectiveNodes(entryA);
-  if (nodesA.length === 0) return;
+  if (nodesA.length === 0) {return;}
 
   const aLast = nodesA[nodesA.length - 1]!;
   const aFirst = nodesA[0]!;
@@ -379,7 +379,7 @@ function autoTrimPair(entryA: EditorWayEntry, entryB: EditorWayEntry): void {
  * first way in the layout (for loop closure).
  */
 function autoTrim(layout: EditorLayout): void {
-  if (layout.ways.length < 2) return;
+  if (layout.ways.length < 2) {return;}
 
   const newEntry = layout.ways[layout.ways.length - 1]!;
   const prevEntry = layout.ways[layout.ways.length - 2]!;
@@ -397,10 +397,10 @@ function autoTrim(layout: EditorLayout): void {
 // --- Way click handler ---
 
 function handleWayClick(wayId: number): void {
-  if (!activeSelectLayoutId) return;
+  if (!activeSelectLayoutId) {return;}
 
   const layout = editorLayouts.find(l => l.id === activeSelectLayoutId);
-  if (!layout) return;
+  if (!layout) {return;}
 
   const existingIdx = layout.ways.findIndex(w => w.wayId === wayId);
   if (existingIdx >= 0) {
@@ -420,19 +420,19 @@ function handleWayClick(wayId: number): void {
 function getWayIdsInAnyLayout(): Set<number> {
   const ids = new Set<number>();
   for (const layout of editorLayouts) {
-    for (const entry of layout.ways) ids.add(entry.wayId);
+    for (const entry of layout.ways) {ids.add(entry.wayId);}
   }
   return ids;
 }
 
 function getActiveLayoutWayIds(): Set<number> {
-  if (!activeSelectLayoutId) return new Set();
+  if (!activeSelectLayoutId) {return new Set();}
   const layout = editorLayouts.find(l => l.id === activeSelectLayoutId);
   return layout ? new Set(layout.ways.map(w => w.wayId)) : new Set();
 }
 
 function clearTrimOverlays(): void {
-  for (const layer of trimOverlayLayers) map.removeLayer(layer);
+  for (const layer of trimOverlayLayers) {map.removeLayer(layer);}
   trimOverlayLayers = [];
 }
 
@@ -481,17 +481,17 @@ function updateWayStyles(): void {
         }
       } else {
         // No trim — show full way in cyan
-        if (way) layer.setLatLngs(way.nodes.map((n: LatLon) => [n.lat, n.lon]));
+        if (way) {layer.setLatLngs(way.nodes.map((n: LatLon) => [n.lat, n.lon]));}
         layer.setStyle({ color: WAY_COLOR_ACTIVE, weight: 5, opacity: 1 });
       }
     } else if (inAnyLayout.has(wayId)) {
       // Restore full geometry for ways no longer in the active layout
       const way = wayDataById.get(wayId);
-      if (way) layer.setLatLngs(way.nodes.map((n: LatLon) => [n.lat, n.lon]));
+      if (way) {layer.setLatLngs(way.nodes.map((n: LatLon) => [n.lat, n.lon]));}
       layer.setStyle({ color: WAY_COLOR_IN_LAYOUT, weight: 4, opacity: 0.85 });
     } else {
       const way = wayDataById.get(wayId);
-      if (way) layer.setLatLngs(way.nodes.map((n: LatLon) => [n.lat, n.lon]));
+      if (way) {layer.setLatLngs(way.nodes.map((n: LatLon) => [n.lat, n.lon]));}
       const isRaceway = String(way?.tags.highway ?? '').toLowerCase() === 'raceway';
       layer.setStyle({
         color: isRaceway ? WAY_COLOR_RACEWAY : WAY_COLOR_DEFAULT,
@@ -507,11 +507,11 @@ function updateWayStyles(): void {
 function enterTrimMode(layoutId: string, wayIdx: number, field: 'fromNode' | 'toNode'): void {
   clearTrimMarkers();
   const layout = editorLayouts.find(l => l.id === layoutId);
-  if (!layout) return;
+  if (!layout) {return;}
   const entry = layout.ways[wayIdx];
-  if (!entry) return;
+  if (!entry) {return;}
   const way = wayDataById.get(entry.wayId);
-  if (!way) return;
+  if (!way) {return;}
 
   trimTarget = { layoutId, wayIdx, field };
   setStatus(`Click a node on way ${entry.wayId} to set ${field === 'fromNode' ? 'start' : 'end'} point. Press Escape to cancel.`);
@@ -534,11 +534,11 @@ function enterTrimMode(layoutId: string, wayIdx: number, field: 'fromNode' | 'to
 }
 
 function applyTrimSelection(node: LatLon): void {
-  if (!trimTarget) return;
+  if (!trimTarget) {return;}
   const layout = editorLayouts.find(l => l.id === trimTarget!.layoutId);
-  if (!layout) return;
+  if (!layout) {return;}
   const entry = layout.ways[trimTarget.wayIdx];
-  if (!entry) return;
+  if (!entry) {return;}
 
   entry[trimTarget.field] = { lat: node.lat, lon: node.lon };
   exitTrimMode();
@@ -552,7 +552,7 @@ function exitTrimMode(): void {
 }
 
 function clearTrimMarkers(): void {
-  for (const marker of trimMarkers) map.removeLayer(marker);
+  for (const marker of trimMarkers) {map.removeLayer(marker);}
   trimMarkers = [];
 }
 
@@ -801,7 +801,7 @@ function wireLayoutEvents(): void {
   // Collapse toggle
   for (const header of layoutsContainer.querySelectorAll('.layout-card-header')) {
     header.addEventListener('click', (e) => {
-      if ((e.target as HTMLElement).closest('.layout-card-delete')) return;
+      if ((e.target as HTMLElement).closest('.layout-card-delete')) {return;}
       const layoutId = (header as HTMLElement).dataset.layoutId!;
       const layout = editorLayouts.find(l => l.id === layoutId);
       if (layout) {
@@ -819,7 +819,7 @@ function wireLayoutEvents(): void {
       const idx = editorLayouts.findIndex(l => l.id === layoutId);
       if (idx >= 0) {
         editorLayouts.splice(idx, 1);
-        if (activeSelectLayoutId === layoutId) activeSelectLayoutId = null;
+        if (activeSelectLayoutId === layoutId) {activeSelectLayoutId = null;}
         updateWayStyles();
         renderLayoutsPanel();
         updateSaveBtn();
@@ -836,7 +836,7 @@ function wireLayoutEvents(): void {
         layout.name = input.value;
         const card = input.closest('.layout-card');
         const nameSpan = card?.querySelector('.layout-card-name');
-        if (nameSpan) nameSpan.textContent = layout.name || 'Untitled';
+        if (nameSpan) {nameSpan.textContent = layout.name || 'Untitled';}
       }
     });
     input.addEventListener('click', (e) => e.stopPropagation());
@@ -851,7 +851,7 @@ function wireLayoutEvents(): void {
       } else {
         activeSelectLayoutId = layoutId;
         const layout = editorLayouts.find(l => l.id === layoutId);
-        if (layout) layout.collapsed = false;
+        if (layout) {layout.collapsed = false;}
       }
       exitTrimMode();
       updateWayStyles();
@@ -907,7 +907,7 @@ function wireLayoutEvents(): void {
       const wayId = Number(el.dataset.wayId);
       if (layout) {
         const idx = layout.ways.findIndex(w => w.wayId === wayId);
-        if (idx >= 0) layout.ways.splice(idx, 1);
+        if (idx >= 0) {layout.ways.splice(idx, 1);}
         updateWayStyles();
         renderLayoutsPanel();
         updateSaveBtn();
@@ -978,8 +978,8 @@ function buildExportJson(): LayoutFile {
     layouts[name] = {
       ways: layout.ways.map(entry => {
         const out: LayoutFileWayEntry = { wayId: entry.wayId };
-        if (entry.fromNode) out.fromNode = entry.fromNode;
-        if (entry.toNode) out.toNode = entry.toNode;
+        if (entry.fromNode) {out.fromNode = entry.fromNode;}
+        if (entry.toNode) {out.toNode = entry.toNode;}
         return out;
       }),
     };
@@ -996,7 +996,7 @@ function buildExportJson(): LayoutFile {
 }
 
 function downloadJson(data: object, filename: string): void {
-  const json = JSON.stringify(data, null, 2) + '\n';
+  const json = `${JSON.stringify(data, null, 2)  }\n`;
   const blob = new Blob([json], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -1009,7 +1009,7 @@ function downloadJson(data: object, filename: string): void {
 }
 
 saveBtn.addEventListener('click', () => {
-  if (!currentTrackId || editorLayouts.length === 0) return;
+  if (!currentTrackId || editorLayouts.length === 0) {return;}
   const data = buildExportJson();
   downloadJson(data, `${currentTrackId}.json`);
 });

--- a/src/model/track-model.ts
+++ b/src/model/track-model.ts
@@ -9,6 +9,8 @@ import {
 import type { TrackModel, OutlinePoints, BasePlate } from '../types/model.js';
 import type { Point2D, ProjectedNode } from '../types/geometry.js';
 import type { RankedPlacements } from '../types/text.js';
+import { selectAndExpandPlacement } from '../text/mesh.js';
+import { buildContourTree, collectShapes } from '../text/contours.js';
 import type { PerfTimer } from './perf-timer.js';
 import {
   BASE_THICKNESS_MM,
@@ -22,8 +24,6 @@ import {
   computeScale,
   type CoasterPocketSpec,
 } from './base-plate.js';
-import { selectAndExpandPlacement } from '../text/mesh.js';
-import { buildContourTree, collectShapes } from '../text/contours.js';
 import { buildTrackPrismMesh, __setTrackPrismPerfCounters } from './track-prism.js';
 import {
   COASTER_TRACK_HEIGHT_FLUSH_MM,

--- a/src/text/placement.ts
+++ b/src/text/placement.ts
@@ -827,7 +827,7 @@ export function dedupeRankedPlacements(
   placements: RankedTextPlacement[],
   scaledBasePlate: Rect2D,
 ): RankedTextPlacement[] {
-  if (placements.length <= 1) return placements;
+  if (placements.length <= 1) {return placements;}
 
   const diagSq = scaledBasePlate.width ** 2 + scaledBasePlate.height ** 2;
   const maxDist = (diagSq > 0 ? Math.sqrt(diagSq) : 1) / 2;

--- a/test/picker.test.ts
+++ b/test/picker.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../src/search/layout-picker.js';
 import { expectDistinctLayouts } from '../test-utils/layout-assertions.js';
 
-function loadFixture(name: string): any {
+function loadFixture(name: string): unknown {
   return JSON.parse(readFileSync(new URL(`./fixtures/${name}`, import.meta.url), 'utf8'));
 }
 
@@ -37,7 +37,7 @@ test('picker state is hidden when only one layout is available', () => {
 test('picker state is shown when multiple layouts are available', () => {
   const fixture = loadFixture('silverstone.json');
 
-  const result = buildTrackGeometryFromPayload(fixture, 'Silverstone Circuit');
+  const result = buildTrackGeometryFromPayload(fixture as Parameters<typeof buildTrackGeometryFromPayload>[0], 'Silverstone Circuit');
   assert.ok(result);
   const pickerState = buildLayoutPickerState(result.layouts, result.selectedLayoutIndex);
 
@@ -51,7 +51,7 @@ test('picker state is shown when multiple layouts are available', () => {
 test('changing selected layout index yields different nodes', () => {
   const fixture = loadFixture('silverstone.json');
 
-  const result = buildTrackGeometryFromPayload(fixture, 'Silverstone Circuit');
+  const result = buildTrackGeometryFromPayload(fixture as Parameters<typeof buildTrackGeometryFromPayload>[0], 'Silverstone Circuit');
   assert.ok(result);
 
   const firstLayout = getSelectedLayout(result.layouts, normalizeSelectedLayoutIndex(result.layouts, 0))!;
@@ -64,7 +64,7 @@ test('changing selected layout index yields different nodes', () => {
 test('picker data never exposes identical returned layouts', () => {
   const fixture = loadFixture('bahrain.json');
 
-  const result = buildTrackGeometryFromPayload(fixture, 'Bahrain International Circuit');
+  const result = buildTrackGeometryFromPayload(fixture as Parameters<typeof buildTrackGeometryFromPayload>[0], 'Bahrain International Circuit');
   assert.ok(result);
 
   for (let index = 0; index < result.layouts.length; index += 1) {

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -38,7 +38,11 @@ const GEOMETRY_HINTS: Record<string, GeometryHints> = {
   },
 };
 
-function loadFixture(name: string): any {
+interface OsmFixture {
+  elements: Array<{ id: number; tags: Record<string, string>; geometry: LatLonNode[] }>;
+}
+
+function loadFixture(name: string): { elements?: unknown[] } {
   return JSON.parse(readFileSync(new URL(`./fixtures/${name}`, import.meta.url), 'utf8'));
 }
 
@@ -59,8 +63,8 @@ function assertLayoutInvariants(layout: { name: string; nodes: LatLonNode[] }, {
 }
 
 function fixtureWays(name: string): Way[] {
-  const fixture = loadFixture(name);
-  return fixture.elements.map((element: any) => ({
+  const fixture = loadFixture(name) as OsmFixture;
+  return fixture.elements.map((element) => ({
     id: element.id,
     tags: element.tags,
     nodes: element.geometry,
@@ -103,7 +107,7 @@ function n(lat: number, lon: number): LatLonNode {
 }
 
 function makeIndexedTrack(record: Record<string, unknown>) {
-  const entry = buildTrackSearchEntry(record as any);
+  const entry = buildTrackSearchEntry(record as Parameters<typeof buildTrackSearchEntry>[0]);
   assert.ok(entry, `expected valid search entry for ${record.wikidataId}`);
   return entry;
 }
@@ -427,7 +431,7 @@ test('searchTracks uses the shipped local search index and returns compatible fi
 test('getTrackGeometry lazily loads and caches the prebuilt supported track layouts', async () => {
   const originalFetch = globalThis.fetch;
   const calls: unknown[] = [];
-  globalThis.fetch = (async (url: any) => {
+  globalThis.fetch = (async (url: RequestInfo | URL) => {
     calls.push(url);
     if (url === '/generated/geometry/Q171402.json') {
       return {
@@ -516,7 +520,7 @@ test('fetchTrackGeometry returns prebuilt local geometry when available', async 
   };
 
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async (url: any) => {
+  globalThis.fetch = (async (url: RequestInfo | URL) => {
     if (String(url).includes('/generated/geometry/Q172851.json')) {
       return { ok: true, async json() { return prebuiltEntry; } };
     }
@@ -524,7 +528,7 @@ test('fetchTrackGeometry returns prebuilt local geometry when available', async 
   }) as typeof fetch;
 
   try {
-    const result = await fetchTrackGeometry('Circuit de Spa-Francorchamps', { wikidataId: 'Q172851' }) as any;
+    const result = await fetchTrackGeometry('Circuit de Spa-Francorchamps', { wikidataId: 'Q172851' }) as { trackId: string; layouts: { name: string; nodes: LatLonNode[] }[] };
     assert.equal(result.trackId, 'Q172851');
     assertLayoutNames(result.layouts, ['Main', 'Alternate']);
   } finally {
@@ -552,7 +556,7 @@ test('build-only geometry cleanup is not applied to runtime payload parsing by d
   };
 
   const runtimeResult = buildTrackGeometryFromPayload(payload, 'Synthetic Circuit');
-  const buildResult = normalizeTrackGeometryResult(runtimeResult as any, 'Synthetic Circuit');
+  const buildResult = normalizeTrackGeometryResult(runtimeResult as Parameters<typeof normalizeTrackGeometryResult>[0], 'Synthetic Circuit');
 
   assert.ok(runtimeResult);
   assert.ok(buildResult);
@@ -568,7 +572,7 @@ test('buildTrackGeometryFromPayload produces named Silverstone layouts from high
   const fixture = loadFixture('silverstone.json');
 
   const result = buildTrackGeometryFromPayload(fixture, 'Silverstone Circuit');
-  const normalized = normalizeTrackGeometryResult(result as any, 'Silverstone Circuit');
+  const normalized = normalizeTrackGeometryResult(result as Parameters<typeof normalizeTrackGeometryResult>[0], 'Silverstone Circuit');
 
   assert.ok(result);
   assert.ok(normalized);

--- a/test/text3d.test.ts
+++ b/test/text3d.test.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import type { Font } from 'opentype.js';
+
+import type { RankedTextPlacement } from '../src/types/text.js';
 import { BASE_THICKNESS_MM } from '../src/model/index.js';
 import { rotateOutlineByOrientation } from '../src/model/orientation.js';
 import {
@@ -400,7 +403,7 @@ test('ranked placements sort by score, then candidate index', () => {
     { id: 'lower-score', score: 9, candidateIndex: 2 },
     { id: 'best-score-lowest-candidate', score: 10, candidateIndex: 0 },
     { id: 'best-score-higher-candidate', score: 10, candidateIndex: 1 },
-  ].sort((a, b) => __debugCompareRankedTextPlacements(a as any, b as any));
+  ].sort((a, b) => __debugCompareRankedTextPlacements(a as unknown as RankedTextPlacement, b as unknown as RankedTextPlacement));
 
   assert.deepEqual(placements.map(({ id }) => id), [
     'best-score-lowest-candidate',
@@ -533,7 +536,7 @@ test('multiline line stacking preserves top-to-bottom order without rotation', (
   assert.ok(layout);
   assert.ok(layout.lines.length > 1, `expected multiline, got: ${JSON.stringify(layout.lines)}`);
   assert.equal(collapseWhitespace(layout.text), 'Autodromo Nazionale di Monza');
-  assertRenderedLineOrder(layout as any);
+  assertRenderedLineOrder(layout as unknown as { lines: string[]; lineBounds: Bounds[] });
 });
 
 test('placement rank does not alter word order', () => {
@@ -721,7 +724,7 @@ test('scored placements expose textClearanceMultiplier in the expected range', (
   const basePlate = { minX: -200, maxX: 4200, minY: -200, maxY: 2700, width: 4400, height: 2900 };
 
   const result = computeRankedTextPlacements('Circuit Name', outline, basePlate, 1, {
-    font: createMockFont() as any,
+    font: createMockFont() as unknown as Font,
   });
 
   assert.ok(result);
@@ -753,10 +756,10 @@ test('text clearance multiplier is higher when text has more breathing room from
   const basePlate = { minX: 0, maxX: 2200, minY: 0, maxY: 2200, width: 2200, height: 2200 };
 
   const shortResult = computeRankedTextPlacements('GO', outline, basePlate, 1, {
-    font: createMockFont() as any,
+    font: createMockFont() as unknown as Font,
   });
   const longResult = computeRankedTextPlacements('A Very Long Circuit Name', outline, basePlate, 1, {
-    font: createMockFont() as any,
+    font: createMockFont() as unknown as Font,
   });
 
   assert.ok(shortResult);
@@ -791,7 +794,7 @@ test('text clearance multiplier is above the floor when text is far from the tra
   const basePlate = { minX: -200, maxX: 6200, minY: -200, maxY: 6200, width: 6400, height: 6400 };
 
   const result = computeRankedTextPlacements('Hi', outline, basePlate, 1, {
-    font: createMockFont() as any,
+    font: createMockFont() as unknown as Font,
   });
 
   assert.ok(result);
@@ -936,10 +939,14 @@ test('DP produces valid splits when all words render to zero width', () => {
 });
 
 test('DP measures space width via fallback when charToGlyph is unavailable', () => {
-  const font = createMockFont() as any;
+  const font = createMockFont() as {
+    charToGlyph?: unknown;
+    unitsPerEm?: unknown;
+    getPath: (...args: unknown[]) => unknown;
+  };
   delete font.charToGlyph;
   delete font.unitsPerEm;
-  const lines = __findOptimalLineBreaks('Las Vegas Strip Circuit', 2, font) as string[];
+  const lines = __findOptimalLineBreaks('Las Vegas Strip Circuit', 2, font as unknown as Font) as string[];
   assert.equal(lines.length, 2);
   assert.equal(lines.join(' '), 'Las Vegas Strip Circuit');
 });


### PR DESCRIPTION
## Summary

Fixes **all 66 ESLint problems** (36 errors + 30 warnings) to a clean **0 errors / 0 warnings** state. Driven by an approved internal plan.

### Errors (auto-fixed, behavior-preserving)
- `curly` and `prefer-template` in `src/layout-editor/entry.ts`
- `curly` in `src/text/placement.ts`
- `import-x/order` in `src/model/track-model.ts`

These were resolved with `eslint --fix` — only brace-wrapping, a template-literal rewrite, and import reordering; no logic changes.

### Warnings (`@typescript-eslint/no-explicit-any`) — replaced with genuine types
- `scripts/build-track-search-index.ts`: introduced local Wikidata interfaces (`SparqlBinding`, `MergedTrackRow`, `EntityDetail`, `WikidataClaim`, `WikidataAlias`, `WikidataEntity`) and typed `fetchJson` as `Promise<unknown>` with narrowing casts at call sites.
- `test/picker.test.ts` / `test/search.test.ts`: `loadFixture` no longer returns `any`; fetch-mock `url` typed as `RequestInfo | URL`; result casts use the real `Parameters<typeof fn>[0]` / narrow object shapes; a minimal `OsmFixture` interface narrows the fixture ways.
- `test/text3d.test.ts`: mock-font casts use the opentype `Font` type, and ranked-placement stubs use `RankedTextPlacement`.

No `// eslint-disable` directives were added or removed (count unchanged at 9), and `eslint.config.js` is untouched.

## Out of scope
File-size refactors of the oversized files were intentionally **not** done. Three oversized files (`src/layout-editor/entry.ts`, `src/text/placement.ts`, `src/model/track-model.ts`) were touched **only** for incidental lint fixes — no splitting or logic changes.

## Verification
- `npm run lint` → 0 errors, 0 warnings
- `npm run typecheck` → clean
- `npm test` → 163 pass, 0 fail
- `npm run build` → succeeds

This work was driven by an approved internal plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)