### PR TITLE
Add mesh-validation sweep across prebuilt geometry corpus

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check:file-sizes": "node --import tsx/esm scripts/check-file-sizes.ts",
+    "validate:meshes": "node --import tsx/esm scripts/validate-meshes.ts",
     "check": "npm run typecheck && npm run lint && npm test && npm run check:file-sizes"
   },
   "devDependencies": {

--- a/scripts/validate-meshes.ts
+++ b/scripts/validate-meshes.ts
@@ -1,0 +1,130 @@
+/**
+ * validate:meshes — mesh-validation sweep across the prebuilt geometry corpus (#122).
+ *
+ * Reads the shipped `src/generated/geometry/*.json` files, builds each track headlessly
+ * through the SAME `buildTrackModel` worker/export path the in-app export uses, runs the
+ * merged `validateModel()` entry point on every part, and prints a compact failure table
+ * keyed by track id + mode + part.
+ *
+ * Modes:
+ *   (no args)        representative sample, auto-trimmed 'sample' matrix (tens of seconds).
+ *   --all            all buildable tracks, lean 8-mode 'all' matrix (on-demand, slow).
+ *   --track <id>     one track, full cross-product matrix.
+ *   --help           usage.
+ *
+ * No mesh fixes live here; the sweep captures the current baseline. Exits non-zero on any
+ * failure. The sweep core lives in `test-utils/mesh-sweep.ts` so the committed test runs
+ * the same code path.
+ */
+
+import {
+  REPRESENTATIVE_SAMPLE,
+  buildableTrackIds,
+  formatFailureTable,
+  readTrackFile,
+  isBuildable,
+  runSweep,
+} from '../test-utils/mesh-sweep.js';
+
+const USAGE = `Usage: npm run validate:meshes [-- <options>]
+
+  (no options)     Run the representative sample (auto-trimmed matrix). Default.
+  --all            Run every buildable track (lean 8-mode matrix). Slow, on-demand.
+  --track <id>     Run a single track by wikidata id (full cross-product matrix).
+  --help           Show this message.
+
+Exits non-zero if any (track, mode, part) fails the current mesh detectors
+(non-manifold edges or degenerate triangles).`;
+
+interface ParsedArgs {
+  help: boolean;
+  all: boolean;
+  track: string | null;
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const parsed: ParsedArgs = { help: false, all: false, track: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      parsed.help = true;
+    } else if (arg === '--all') {
+      parsed.all = true;
+    } else if (arg === '--track') {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('-')) {
+        throw new Error('--track requires a wikidata id, e.g. --track Q172851');
+      }
+      parsed.track = value;
+      i += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  let args: ParsedArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    console.error(`\n${USAGE}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (args.help) {
+    console.log(USAGE);
+    return;
+  }
+
+  if (args.track) {
+    const file = readTrackFile(args.track);
+    if (file === null) {
+      console.error(`Unknown track id: ${args.track} (no geometry file found)`);
+      process.exitCode = 1;
+      return;
+    }
+    if (!isBuildable(file)) {
+      console.error(`Track ${args.track} has no buildable geometry (stub or <3 nodes)`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`validate:meshes — single track ${args.track} (full matrix)\n`);
+    const result = runSweep([args.track], { variant: 'full' });
+    report(result, 1);
+    return;
+  }
+
+  if (args.all) {
+    const ids = buildableTrackIds();
+    console.log(`validate:meshes — all ${ids.length} buildable tracks (lean matrix). This may take minutes.\n`);
+    const started = Date.now();
+    const result = runSweep(ids, { variant: 'all' });
+    console.log(`(${((Date.now() - started) / 1000).toFixed(1)}s)\n`);
+    report(result, ids.length);
+    return;
+  }
+
+  console.log(`validate:meshes — representative sample of ${REPRESENTATIVE_SAMPLE.length} tracks (auto-trimmed matrix)\n`);
+  const started = Date.now();
+  const result = runSweep(REPRESENTATIVE_SAMPLE, { variant: 'sample' });
+  console.log(`(${((Date.now() - started) / 1000).toFixed(1)}s)\n`);
+  report(result, REPRESENTATIVE_SAMPLE.length);
+}
+
+function report(result: ReturnType<typeof runSweep>, requested: number): void {
+  if (result.failures.length === 0) {
+    console.log(`validate:meshes — ${result.built} tracks, 0 failures`);
+    return;
+  }
+  console.log(formatFailureTable(result, requested));
+  process.exitCode = 1;
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/test-utils/mesh-sweep.ts
+++ b/test-utils/mesh-sweep.ts
@@ -1,0 +1,437 @@
+/**
+ * Shared mesh-validation sweep core (issue #122).
+ *
+ * Pure, importable engine with NO `process.exit` and NO `console` output: given a
+ * track record + a build mode it produces a structured result, and given a list of
+ * track ids it returns aggregated `SweepFailure[]`. Both the CLI sweep
+ * (`scripts/validate-meshes.ts`) and the committed test
+ * (`test/mesh-sweep-sample.test.ts`) import this, so the test validates the SAME
+ * code path the CLI runs.
+ *
+ * Builds go through the worker/export path exactly as `src/workers/model.worker.ts`
+ * does: `buildTrackModel({ outlinePoints: null, basePlate: null, ... })` derives the
+ * real outline + base plate internally, then `validateModel()` (src/model/validate-mesh.ts,
+ * from #121/#123) runs the current non-manifold + degenerate detectors on every part.
+ *
+ * The failure predicate and row formatter iterate `report.parts` generically, so the
+ * #109 (T-junction) and #115 (self-intersection / flipped winding / disjoint shell)
+ * detectors slot in later by extending `validateModel` / `PartReport` and adding one
+ * line to `partFailed` + the formatter — no structural change here.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { projectNodes } from '../src/geometry/projection.js';
+import { buildTrackModel } from '../src/model/track-model.js';
+import { validateModel } from '../src/model/validate-mesh.js';
+import type { PartReport } from '../src/model/validate-mesh.js';
+import type { LatLonNode } from '../src/types/geometry.js';
+
+// ── Geometry corpus reading (no network) ──────────────────────────────────────
+
+/** Minimal local shape of a buildable prebuilt geometry file. */
+export interface PrebuiltTrackFile {
+  trackId: string;
+  name?: string;
+  center?: { lat: number; lon: number };
+  names?: { searchLabel?: string | null };
+  layouts?: { id?: string; name?: string; nodes?: LatLonNode[] }[];
+  selectedLayoutIndex?: number;
+}
+
+const GEOMETRY_DIR = new URL('../src/generated/geometry', import.meta.url).pathname;
+
+/** A layout is buildable when it has at least 3 nodes (a valid chain). */
+function buildableLayouts(file: PrebuiltTrackFile): { name: string; nodes: LatLonNode[] }[] {
+  return (file.layouts ?? [])
+    .filter((l): l is { id?: string; name?: string; nodes: LatLonNode[] } =>
+      Array.isArray(l.nodes) && l.nodes.length >= 3,
+    )
+    .map(l => ({ name: l.name ?? l.id ?? '', nodes: l.nodes }));
+}
+
+/** True iff the file has at least one buildable layout. */
+export function isBuildable(file: PrebuiltTrackFile): boolean {
+  return buildableLayouts(file).length > 0;
+}
+
+/** The printed track label resolved the same way the runtime does. */
+export function trackLabel(file: PrebuiltTrackFile): string {
+  return file.names?.searchLabel ?? file.name ?? file.trackId;
+}
+
+/** Reads one geometry file by wikidata id, or returns null if missing. */
+export function readTrackFile(trackId: string): PrebuiltTrackFile | null {
+  try {
+    const raw = readFileSync(join(GEOMETRY_DIR, `${trackId}.json`), 'utf-8');
+    return JSON.parse(raw) as PrebuiltTrackFile;
+  } catch {
+    return null;
+  }
+}
+
+/** All track ids that have a geometry file (buildable or stub), sorted. */
+export function allTrackIds(): string[] {
+  return readdirSync(GEOMETRY_DIR)
+    .filter(f => f.endsWith('.json'))
+    .map(f => f.slice(0, -'.json'.length))
+    .sort();
+}
+
+/** All buildable track ids, sorted. */
+export function buildableTrackIds(): string[] {
+  return allTrackIds().filter(id => {
+    const file = readTrackFile(id);
+    return file !== null && isBuildable(file);
+  });
+}
+
+// ── Mode matrix ───────────────────────────────────────────────────────────────
+
+export interface Mode {
+  coaster: boolean;
+  coasterInlay: 'flush' | 'raised';
+  coasterShape: 'round' | 'square';
+  orientationDeg: number | 'auto';
+  /** When true and the track has >1 layout, the other layouts build as secondaries. */
+  combined: boolean;
+}
+
+export type SweepVariant = 'sample' | 'all' | 'full';
+
+/** Human-readable mode string for the failure table. */
+export function modeLabel(mode: Mode): string {
+  const orient = mode.orientationDeg === 'auto' ? 'auto' : `${mode.orientationDeg}deg`;
+  const layouts = mode.combined ? 'combined' : 'single';
+  if (!mode.coaster) {
+    return `flat/${orient}/${layouts}`;
+  }
+  return `coaster-${mode.coasterInlay}-${mode.coasterShape}/${orient}/${layouts}`;
+}
+
+/** Default non-coaster sub-axes (inlay/shape are no-ops when coaster:false). */
+const FLAT: Pick<Mode, 'coaster' | 'coasterInlay' | 'coasterShape'> = {
+  coaster: false,
+  coasterInlay: 'raised',
+  coasterShape: 'round',
+};
+
+/**
+ * Enumerates the build modes for a track under a given variant. Pure function — the
+ * tables in the plan ARE this code. `multiLayout` adds `combined` variants only when
+ * the track actually has more than one buildable layout.
+ */
+export function enumerateModes(multiLayout: boolean, variant: SweepVariant): Mode[] {
+  if (variant === 'sample') {
+    // auto-trimmed 5-mode matrix: exactly ONE `auto` build per track.
+    const base: Mode[] = [
+      { ...FLAT, orientationDeg: 'auto', combined: false },
+      { ...FLAT, orientationDeg: 0, combined: false },
+      { ...FLAT, orientationDeg: 90, combined: false },
+      { coaster: true, coasterInlay: 'flush', coasterShape: 'round', orientationDeg: 0, combined: false },
+      { coaster: true, coasterInlay: 'raised', coasterShape: 'square', orientationDeg: 90, combined: false },
+    ];
+    if (multiLayout) {
+      base.push({ ...FLAT, orientationDeg: 'auto', combined: true });
+      base.push({ coaster: true, coasterInlay: 'flush', coasterShape: 'round', orientationDeg: 0, combined: true });
+    }
+    return base;
+  }
+
+  if (variant === 'all') {
+    // lean 8-mode matrix (auto-heavy — on-demand only).
+    const base: Mode[] = [
+      { ...FLAT, orientationDeg: 'auto', combined: false },
+      { ...FLAT, orientationDeg: 0, combined: false },
+      { ...FLAT, orientationDeg: 90, combined: false },
+      { coaster: true, coasterInlay: 'raised', coasterShape: 'round', orientationDeg: 'auto', combined: false },
+      { coaster: true, coasterInlay: 'flush', coasterShape: 'round', orientationDeg: 'auto', combined: false },
+      { coaster: true, coasterInlay: 'raised', coasterShape: 'square', orientationDeg: 'auto', combined: false },
+      { coaster: true, coasterInlay: 'flush', coasterShape: 'square', orientationDeg: 'auto', combined: false },
+      { coaster: true, coasterInlay: 'flush', coasterShape: 'round', orientationDeg: 0, combined: false },
+    ];
+    if (multiLayout) {
+      base.push({ ...FLAT, orientationDeg: 'auto', combined: true });
+      base.push({ coaster: true, coasterInlay: 'flush', coasterShape: 'round', orientationDeg: 'auto', combined: true });
+      base.push({ coaster: true, coasterInlay: 'raised', coasterShape: 'round', orientationDeg: 'auto', combined: true });
+    }
+    return base;
+  }
+
+  // 'full' cross-product — single track, on demand.
+  const modes: Mode[] = [];
+  const orientations: (number | 'auto')[] = ['auto', 0, 90];
+  const layoutVariants = multiLayout ? [false, true] : [false];
+  for (const combined of layoutVariants) {
+    for (const orientationDeg of orientations) {
+      modes.push({ ...FLAT, orientationDeg, combined });
+    }
+    for (const coasterInlay of ['raised', 'flush'] as const) {
+      for (const coasterShape of ['round', 'square'] as const) {
+        for (const orientationDeg of orientations) {
+          modes.push({ coaster: true, coasterInlay, coasterShape, orientationDeg, combined });
+        }
+      }
+    }
+  }
+  return modes;
+}
+
+// ── Building + validating one (track, mode) ───────────────────────────────────
+
+export interface SweepFailure {
+  trackId: string;
+  trackLabel: string;
+  mode: string;
+  part: PartReport['part'] | 'build';
+  nonManifoldEdges: number;
+  degenerateTriangles: number;
+  /** From nonManifoldEdges[0], rounded to 4dp. */
+  firstEdge?: { a: { x: number; y: number; z: number }; b: { x: number; y: number; z: number } };
+  buildError?: string;
+}
+
+/** Failure predicate for a part — extend here when #109/#115 fields land on PartReport. */
+function partFailed(part: PartReport): boolean {
+  return part.nonManifoldEdges.length > 0 || part.degenerateTriangles.length > 0;
+}
+
+function round4(n: number): number {
+  return +n.toFixed(4);
+}
+
+/**
+ * Builds one (track, mode) through the worker/export path and validates it.
+ * Returns the failure rows for this single build (empty when clean). A thrown build
+ * error becomes one row with `part: 'build'` so a crash on a hard track is reported.
+ */
+export function sweepOne(file: PrebuiltTrackFile, mode: Mode): SweepFailure[] {
+  const label = trackLabel(file);
+  const layouts = buildableLayouts(file);
+  const primaryIndex =
+    file.selectedLayoutIndex !== undefined && file.selectedLayoutIndex < layouts.length
+      ? file.selectedLayoutIndex
+      : 0;
+  const primary = layouts[primaryIndex]!;
+  const others = layouts.filter((_, i) => i !== primaryIndex);
+  const center = file.center ?? null;
+
+  try {
+    const projected = projectNodes(primary.nodes, null, center);
+    const secondaryProjectedNodes =
+      mode.combined && others.length > 0
+        ? others.map(l => projectNodes(l.nodes, null, center))
+        : [];
+
+    const model = buildTrackModel({
+      outlinePoints: null,
+      basePlate: null,
+      trackName: label,
+      projectedNodes: projected,
+      secondaryProjectedNodes,
+      primaryOrientationDeg: mode.orientationDeg,
+      coasterMode: mode.coaster,
+      coasterShape: mode.coasterShape,
+      coasterInlay: mode.coasterInlay,
+      trackWidthAuto: true,
+    });
+
+    const report = validateModel(model);
+    const failures: SweepFailure[] = [];
+    for (const part of report.parts) {
+      if (!partFailed(part)) {
+        continue;
+      }
+      const first = part.nonManifoldEdges[0];
+      failures.push({
+        trackId: file.trackId,
+        trackLabel: label,
+        mode: modeLabel(mode),
+        part: part.part,
+        nonManifoldEdges: part.nonManifoldEdges.length,
+        degenerateTriangles: part.degenerateTriangles.length,
+        ...(first
+          ? {
+              firstEdge: {
+                a: { x: round4(first.a.x), y: round4(first.a.y), z: round4(first.a.z) },
+                b: { x: round4(first.b.x), y: round4(first.b.y), z: round4(first.b.z) },
+              },
+            }
+          : {}),
+      });
+    }
+    return failures;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return [
+      {
+        trackId: file.trackId,
+        trackLabel: label,
+        mode: modeLabel(mode),
+        part: 'build',
+        nonManifoldEdges: 0,
+        degenerateTriangles: 0,
+        buildError: message,
+      },
+    ];
+  }
+}
+
+// ── Aggregating over a list of tracks ─────────────────────────────────────────
+
+export interface SweepResult {
+  failures: SweepFailure[];
+  built: number;
+  skipped: { trackId: string; reason: 'no-geometry' }[];
+}
+
+export interface RunSweepOptions {
+  /** Selects the per-track mode matrix. Defaults to 'sample'. */
+  variant?: SweepVariant;
+}
+
+/**
+ * Runs the sweep over a list of track ids. Stub/no-geometry files are recorded as
+ * skipped (never failures). Returns aggregated failures + counts.
+ */
+export function runSweep(trackIds: string[], options: RunSweepOptions = {}): SweepResult {
+  const variant = options.variant ?? 'sample';
+  const failures: SweepFailure[] = [];
+  const skipped: SweepResult['skipped'] = [];
+  let built = 0;
+
+  for (const trackId of trackIds) {
+    const file = readTrackFile(trackId);
+    if (file === null || !isBuildable(file)) {
+      skipped.push({ trackId, reason: 'no-geometry' });
+      continue;
+    }
+    const multiLayout = buildableLayouts(file).length > 1;
+    const modes = enumerateModes(multiLayout, variant);
+    for (const mode of modes) {
+      failures.push(...sweepOne(file, mode));
+    }
+    built += 1;
+  }
+
+  return { failures, built, skipped };
+}
+
+// ── Compact failure table formatting ──────────────────────────────────────────
+
+const COLS = {
+  id: 12,
+  label: 28,
+  mode: 30,
+  part: 10,
+  nm: 8,
+  degen: 7,
+};
+
+function truncate(s: string, width: number): string {
+  return s.length > width ? `${s.slice(0, width - 1)}…` : s;
+}
+
+function formatFirstEdge(f: SweepFailure): string {
+  if (f.buildError) {
+    return `BUILD ERROR: ${f.buildError}`;
+  }
+  if (!f.firstEdge) {
+    return '';
+  }
+  const { a, b } = f.firstEdge;
+  return `(${a.x},${a.y},${a.z})->(${b.x},${b.y},${b.z})`;
+}
+
+/**
+ * Renders the compact failure table: one row per failed (track, mode, part), with a
+ * summary footer. Used both as the CLI stdout table and as the test's assert message.
+ */
+export function formatFailureTable(result: SweepResult, tracksRequested: number): string {
+  const lines: string[] = [];
+  const header =
+    'track id'.padEnd(COLS.id) +
+    'label'.padEnd(COLS.label) +
+    'mode'.padEnd(COLS.mode) +
+    'part'.padEnd(COLS.part) +
+    'nm-edges'.padStart(COLS.nm) +
+    'degens'.padStart(COLS.degen) +
+    '  first edge';
+  lines.push(header);
+  lines.push('-'.repeat(header.length));
+
+  for (const f of result.failures) {
+    lines.push(
+      f.trackId.padEnd(COLS.id) +
+        truncate(f.trackLabel, COLS.label).padEnd(COLS.label) +
+        truncate(f.mode, COLS.mode).padEnd(COLS.mode) +
+        f.part.padEnd(COLS.part) +
+        String(f.nonManifoldEdges).padStart(COLS.nm) +
+        String(f.degenerateTriangles).padStart(COLS.degen) +
+        '  ' +
+        formatFirstEdge(f),
+    );
+  }
+
+  const failedTracks = new Set(result.failures.map(f => f.trackId)).size;
+  lines.push('-'.repeat(header.length));
+  lines.push(
+    `${result.built} tracks built, ${result.skipped.length} skipped (no geometry), ` +
+      `${result.failures.length} failures across ${failedTracks} tracks ` +
+      `(${tracksRequested} requested)`,
+  );
+  return lines.join('\n');
+}
+
+// ── Representative sample (shared by CLI default + committed test) ─────────────
+
+/**
+ * Deterministic, committed representative sample (~40 tracks). Anchored by the
+ * verified known-hard ids (long name, many layouts, hairpins) plus a deterministic
+ * spread sampled every-Nth across the sorted buildable corpus. NOT randomized per run.
+ */
+export const REPRESENTATIVE_SAMPLE: string[] = [
+  // Anchors (known-hard, verified):
+  'Q172851', // Spa-Francorchamps Circuit — long name + 2 layouts
+  'Q171402', // Silverstone Circuit — 6 layouts (heavy combined)
+  'Q171566', // Red Bull Ring — 3 layouts
+  'Q171400', // Circuit de Monaco — tight hairpins, street circuit
+  'Q173099', // 7 layouts (max layout count; combined stress)
+  // Deterministic every-Nth spread across the sorted buildable corpus:
+  'Q102141307',
+  'Q108016849',
+  'Q113455971',
+  'Q116973540',
+  'Q123411911',
+  'Q129408771',
+  'Q135397446',
+  'Q14250583',
+  'Q1523618',
+  'Q1626077',
+  'Q16830288',
+  'Q17004958',
+  'Q171449',
+  'Q172884',
+  'Q1738522',
+  'Q18680802',
+  'Q20022006',
+  'Q222686',
+  'Q2630372',
+  'Q29035351',
+  'Q3208132',
+  'Q390103',
+  'Q4827211',
+  'Q4827237',
+  'Q4879200',
+  'Q5121627',
+  'Q5457795',
+  'Q5713001',
+  'Q5967569',
+  'Q648512',
+  'Q6918074',
+  'Q7170876',
+  'Q7570163',
+  'Q786639',
+  'Q813859',
+];

--- a/test/mesh-sweep-sample.test.ts
+++ b/test/mesh-sweep-sample.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Mesh-validation baseline sweep over the representative sample (#122).
+ *
+ * Runs the SHARED sweep core (`test-utils/mesh-sweep.ts`) — the same code path the
+ * `npm run validate:meshes` CLI runs — over the committed `REPRESENTATIVE_SAMPLE`, and
+ * asserts ZERO mesh failures (non-manifold edges / degenerate triangles) across the
+ * worker/export build path.
+ *
+ * INTENTIONALLY RED (owner decision): several representative tracks already fail the
+ * current detectors. This test asserts zero failures on purpose so the pre-existing
+ * baseline is loud and visible in CI. The assert message is the full compact failure
+ * table (track id, label, mode, part, counts, first offending edge). Do NOT skip/todo
+ * this test or weaken the assertion to make it pass — its redness is the deliverable.
+ * The failures are captured in the PR body and a follow-up issue; no mesh fixes land
+ * with this test.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { REPRESENTATIVE_SAMPLE, formatFailureTable, runSweep } from '../test-utils/mesh-sweep.js';
+
+test('representative sample meshes are 2-manifold and free of degenerate triangles', () => {
+  const result = runSweep(REPRESENTATIVE_SAMPLE, { variant: 'sample' });
+
+  assert.equal(
+    result.failures.length,
+    0,
+    `\nMesh validation sweep found ${result.failures.length} baseline failure(s):\n\n` +
+      `${formatFailureTable(result, REPRESENTATIVE_SAMPLE.length)}\n`,
+  );
+});


### PR DESCRIPTION
## What & why

Adds a mesh-validation **sweep** that runs the existing non-manifold-edge and degenerate-triangle detectors (from #121/#123) across the prebuilt geometry corpus and the full mode matrix. This gives us continuous visibility into mesh quality instead of spot-checking individual tracks.

- `npm run validate:meshes` — representative 40-track sample (auto-trimmed matrix, ~13s). Default.
- `npm run validate:meshes -- --track <id>` — single track, full cross-product matrix (~4s).
- `npm run validate:meshes -- --all` — every buildable track (slow, on-demand).
- `npm run validate:meshes -- --help` — usage.

Files:
- `scripts/validate-meshes.ts` — CLI entry / arg parsing.
- `test-utils/mesh-sweep.ts` — sweep engine, failure predicate, compact table formatter.
- `test/mesh-sweep-sample.test.ts` — wires the sample sweep into the test suite.
- `package.json` — `validate:meshes` script.

## Intentional red test

`test/mesh-sweep-sample.test.ts` is **INTENTIONALLY RED.** It asserts zero failures and currently fails loudly with the baseline table (263 failures across 40 tracks). This is a deliberate owner decision: the failing test surfaces the **pre-existing** mesh baseline so it cannot be silently ignored. **No mesh fixes are included in this PR** — it lands the detection harness only.

All other tests pass: **173 / 174 passing**, the only failure being this new baseline test.

## Pre-existing baseline failures

The defects below are **pre-existing** and merely surfaced by the new sweep — not introduced here. Cleanup is tracked as follow-up in **#125**.

Headline offenders (non-manifold edges; the `combined/secondary` parts are the worst):

```
track id    label                       mode                          part      nm-edges degens  first edge
-----------------------------------------------------------------------------------------------------------
Q171402     Silverstone Circuit         flat/auto/combined            secondary     3839      0  (47.3681,36.7295,5.5)->(46.2388,37.3979,5.5)
Q171402     Silverstone Circuit         coaster-flush-round/0deg/comb…secondary     3846      0  (13.7534,-0.7552,2.5)->(14.2627,0.1054,2.5)
Q173099     Autódromo Hermanos Rodríguezflat/auto/combined            secondary     6220      0  (-19.6983,-20.8443,5.5)->(-20.414,-22.2037,5.5)
Q173099     Autódromo Hermanos Rodríguezcoaster-flush-round/0deg/comb…secondary     6220      0  (-1.0592,5.5118,2.5)->(-1.525,4.627,2.5)
Q1626077    Homestead-Miami Speedway    coaster-flush-round/0deg/sing…base            16     42  (-24.4491,38.7691,2.5)->(-30.2202,33.3428,2.5)
Q1626077    Homestead-Miami Speedway    flat/auto/combined            secondary     4572      0  (52.422,-10.0831,5.5)->(53.7106,-12.0939,5.5)
Q1626077    Homestead-Miami Speedway    coaster-flush-round/0deg/comb…base            20     42  (-24.4491,38.7691,2.5)->(-30.2202,33.3428,2.5)
Q1626077    Homestead-Miami Speedway    coaster-flush-round/0deg/comb…secondary     4548      0  (-23.8299,2.7217,2.5)->(-24.3694,3.5637,2.5)
Q171449     Watkins Glen International  flat/auto/combined            secondary     1896      0  (38.5063,60.3656,5.5)->(38.5435,59.083,5.5)
Q171449     Watkins Glen International  coaster-flush-round/0deg/comb…secondary     1896      0  (14.2969,-11.625,2.5)->(13.2973,-11.654,2.5)
Q29035351   Freedom Factory             coaster-flush-round/0deg/sing…base             4     16  (34.9905,-2.3076,2.5)->(33.1318,-2.3076,2.5)
Q4827211    Autódromo Chiapas           coaster-flush-round/0deg/sing…base             8     25  (-22.7398,-33.5302,2.5)->(-23.5086,-33.5302,2.5)
Q5713001    Autódromo La Chutana        coaster-flush-round/0deg/sing…base             9     28  (-6.6029,-44.5129,2.5)->(19.9463,-40.8184,2.5)
```

<details><summary>Full baseline failure table (sample mode, 263 rows)</summary>

```
track id    label                       mode                          part      nm-edges degens  first edge
-----------------------------------------------------------------------------------------------------------
Q172851     Spa-Francorchamps Circuit   flat/auto/single              track            0     30  
Q172851     Spa-Francorchamps Circuit   flat/0deg/single              track            0     44  
Q172851     Spa-Francorchamps Circuit   flat/90deg/single             track            0     26  
Q172851     Spa-Francorchamps Circuit   coaster-flush-round/0deg/sing…base             0     84  
Q172851     Spa-Francorchamps Circuit   coaster-flush-round/0deg/sing…track            0     56  
Q172851     Spa-Francorchamps Circuit   coaster-raised-square/90deg/s…track            0     32  
Q172851     Spa-Francorchamps Circuit   flat/auto/combined            track            0     30  
Q172851     Spa-Francorchamps Circuit   coaster-flush-round/0deg/comb…base             0     84  
Q172851     Spa-Francorchamps Circuit   coaster-flush-round/0deg/comb…track            0     56  
Q171402     Silverstone Circuit         flat/auto/single              track            0     10  
Q171402     Silverstone Circuit         flat/0deg/single              track            0     14  
Q171402     Silverstone Circuit         flat/90deg/single             track            0     10  
Q171402     Silverstone Circuit         coaster-flush-round/0deg/sing…base             0     33  
Q171402     Silverstone Circuit         coaster-flush-round/0deg/sing…track            0     22  
Q171402     Silverstone Circuit         coaster-raised-square/90deg/s…track            0     14  
Q171402     Silverstone Circuit         flat/auto/combined            secondary     3839      0  (47.3681,36.7295,5.5)->(46.2388,37.3979,5.5)
Q171402     Silverstone Circuit         flat/auto/combined            track            0     10  
Q171402     Silverstone Circuit         coaster-flush-round/0deg/comb…base             0     30  
Q171402     Silverstone Circuit         coaster-flush-round/0deg/comb…secondary     3846      0  (13.7534,-0.7552,2.5)->(14.2627,0.1054,2.5)
Q171402     Silverstone Circuit         coaster-flush-round/0deg/comb…track            0     24  
Q171566     Red Bull Ring               flat/auto/single              track            0      8  
Q171566     Red Bull Ring               flat/0deg/single              track            0      8  
Q171566     Red Bull Ring               flat/90deg/single             track            0      6  
Q171566     Red Bull Ring               coaster-flush-round/0deg/sing…base             0     18  
Q171566     Red Bull Ring               coaster-flush-round/0deg/sing…track            0      6  
Q171566     Red Bull Ring               flat/auto/combined            track            0      8  
Q171566     Red Bull Ring               coaster-flush-round/0deg/comb…base             0     18  
Q171566     Red Bull Ring               coaster-flush-round/0deg/comb…track            0      6  
Q171400     Circuit de Monaco           flat/auto/single              track            0      2  
Q171400     Circuit de Monaco           flat/0deg/single              track            0      8  
Q171400     Circuit de Monaco           flat/90deg/single             track            0      2  
Q171400     Circuit de Monaco           coaster-flush-round/0deg/sing…base             0     10  
Q171400     Circuit de Monaco           coaster-flush-round/0deg/sing…track            0      8  
Q171400     Circuit de Monaco           coaster-raised-square/90deg/s…track            0      8  
Q173099     Autódromo Hermanos Rodríguezflat/auto/single              track            0     18  
Q173099     Autódromo Hermanos Rodríguezflat/0deg/single              track            0     18  
Q173099     Autódromo Hermanos Rodríguezflat/90deg/single             track            0     20  
Q173099     Autódromo Hermanos Rodríguezcoaster-flush-round/0deg/sing…base             0     31  
Q173099     Autódromo Hermanos Rodríguezcoaster-flush-round/0deg/sing…track            0     44  
Q173099     Autódromo Hermanos Rodríguezcoaster-raised-square/90deg/s…track            0     32  
Q173099     Autódromo Hermanos Rodríguezflat/auto/combined            secondary     6220      0  (-19.6983,-20.8443,5.5)->(-20.414,-22.2037,5.5)
Q173099     Autódromo Hermanos Rodríguezflat/auto/combined            track            0     18  
Q173099     Autódromo Hermanos Rodríguezcoaster-flush-round/0deg/comb…base             0     31  
Q173099     Autódromo Hermanos Rodríguezcoaster-flush-round/0deg/comb…secondary     6220      0  (-1.0592,5.5118,2.5)->(-1.525,4.627,2.5)
Q173099     Autódromo Hermanos Rodríguezcoaster-flush-round/0deg/comb…track            0     44  
Q102141307  Jeddah Corniche Circuit     flat/auto/single              track            0     20  
Q102141307  Jeddah Corniche Circuit     flat/0deg/single              track            0     16  
Q102141307  Jeddah Corniche Circuit     flat/90deg/single             track            0     20  
Q102141307  Jeddah Corniche Circuit     coaster-flush-round/0deg/sing…base             0     21  
Q102141307  Jeddah Corniche Circuit     coaster-flush-round/0deg/sing…track            0     16  
Q102141307  Jeddah Corniche Circuit     coaster-raised-square/90deg/s…track            0     12  
Q102141307  Jeddah Corniche Circuit     flat/auto/combined            track            0     18  
Q102141307  Jeddah Corniche Circuit     coaster-flush-round/0deg/comb…base             0     21  
Q102141307  Jeddah Corniche Circuit     coaster-flush-round/0deg/comb…track            0     16  
Q108016849  Nashville Street Circuit    flat/auto/single              track            0      8  
Q108016849  Nashville Street Circuit    flat/0deg/single              track            0      4  
Q108016849  Nashville Street Circuit    flat/90deg/single             track            0      8  
Q108016849  Nashville Street Circuit    coaster-flush-round/0deg/sing…base             0     17  
Q108016849  Nashville Street Circuit    coaster-flush-round/0deg/sing…track            0     14  
Q108016849  Nashville Street Circuit    coaster-raised-square/90deg/s…track            0      2  
Q113455971  Autódromo Guadalajara       flat/auto/single              track            0     22  
Q113455971  Autódromo Guadalajara       flat/0deg/single              track            0      6  
Q113455971  Autódromo Guadalajara       flat/90deg/single             track            0      6  
Q113455971  Autódromo Guadalajara       coaster-flush-round/0deg/sing…base             0     37  
Q113455971  Autódromo Guadalajara       coaster-flush-round/0deg/sing…track            0     22  
Q113455971  Autódromo Guadalajara       coaster-raised-square/90deg/s…track            0      8  
Q116973540  Circuit Italia              flat/90deg/single             track            0      2  
Q116973540  Circuit Italia              coaster-flush-round/0deg/sing…base             0      1  
Q116973540  Circuit Italia              coaster-flush-round/0deg/sing…track            0      2  
Q123411911  Cremona Circuit             flat/auto/single              track            0      4  
Q123411911  Cremona Circuit             flat/0deg/single              track            0      6  
Q123411911  Cremona Circuit             flat/90deg/single             track            0     24  
Q123411911  Cremona Circuit             coaster-flush-round/0deg/sing…base             0      3  
Q123411911  Cremona Circuit             coaster-flush-round/0deg/sing…track            0      4  
Q123411911  Cremona Circuit             coaster-raised-square/90deg/s…track            0     10  
Q129408771  Tri-City Raceway            flat/auto/single              track            0     22  
Q129408771  Tri-City Raceway            flat/0deg/single              track            0     20  
Q129408771  Tri-City Raceway            flat/90deg/single             track            0     22  
Q129408771  Tri-City Raceway            coaster-flush-round/0deg/sing…base             0     29  
Q129408771  Tri-City Raceway            coaster-flush-round/0deg/sing…track            0     28  
Q129408771  Tri-City Raceway            coaster-raised-square/90deg/s…track            0     26  
Q135397446  Lara Racing Circuit         flat/auto/single              track            0     18  
Q135397446  Lara Racing Circuit         flat/0deg/single              track            0     12  
Q135397446  Lara Racing Circuit         flat/90deg/single             track            0     20  
Q135397446  Lara Racing Circuit         coaster-flush-round/0deg/sing…base             0      8  
Q135397446  Lara Racing Circuit         coaster-flush-round/0deg/sing…track            0     14  
Q135397446  Lara Racing Circuit         coaster-raised-square/90deg/s…track            0     16  
Q14250583   Raceway Venray              flat/auto/single              track            0     30  
Q14250583   Raceway Venray              flat/0deg/single              track            0     32  
Q14250583   Raceway Venray              flat/90deg/single             track            0     30  
Q14250583   Raceway Venray              coaster-flush-round/0deg/sing…base             0     36  
Q14250583   Raceway Venray              coaster-flush-round/0deg/sing…track            0     42  
Q14250583   Raceway Venray              coaster-raised-square/90deg/s…track            0     22  
Q1523618    Las Vegas Motor Speedway    flat/auto/single              track            0     16  
Q1523618    Las Vegas Motor Speedway    flat/0deg/single              track            0     16  
Q1523618    Las Vegas Motor Speedway    flat/90deg/single             track            0     16  
Q1523618    Las Vegas Motor Speedway    coaster-flush-round/0deg/sing…base             0     41  
Q1523618    Las Vegas Motor Speedway    coaster-flush-round/0deg/sing…track            0     30  
Q1523618    Las Vegas Motor Speedway    coaster-raised-square/90deg/s…track            0     12  
Q1626077    Homestead-Miami Speedway    flat/auto/single              track            0     20  
Q1626077    Homestead-Miami Speedway    flat/0deg/single              track            0     20  
Q1626077    Homestead-Miami Speedway    flat/90deg/single             track            0     34  
Q1626077    Homestead-Miami Speedway    coaster-flush-round/0deg/sing…base            16     42  (-24.4491,38.7691,2.5)->(-30.2202,33.3428,2.5)
Q1626077    Homestead-Miami Speedway    coaster-flush-round/0deg/sing…track            0     42  
Q1626077    Homestead-Miami Speedway    coaster-raised-square/90deg/s…track            0     42  
Q1626077    Homestead-Miami Speedway    flat/auto/combined            secondary     4572      0  (52.422,-10.0831,5.5)->(53.7106,-12.0939,5.5)
Q1626077    Homestead-Miami Speedway    flat/auto/combined            track            0     28  
Q1626077    Homestead-Miami Speedway    coaster-flush-round/0deg/comb…base            20     42  (-24.4491,38.7691,2.5)->(-30.2202,33.3428,2.5)
Q1626077    Homestead-Miami Speedway    coaster-flush-round/0deg/comb…secondary     4548      0  (-23.8299,2.7217,2.5)->(-24.3694,3.5637,2.5)
Q1626077    Homestead-Miami Speedway    coaster-flush-round/0deg/comb…track            0     42  
Q16830288   Serres Racing Circuit       flat/auto/single              track            0     20  
Q16830288   Serres Racing Circuit       flat/0deg/single              track            0     20  
Q16830288   Serres Racing Circuit       flat/90deg/single             track            0     24  
Q16830288   Serres Racing Circuit       coaster-flush-round/0deg/sing…base             0     23  
Q16830288   Serres Racing Circuit       coaster-flush-round/0deg/sing…track            0     32  
Q16830288   Serres Racing Circuit       coaster-raised-square/90deg/s…track            0      8  
Q17004958   Baku City Circuit           flat/auto/single              track            0     12  
Q17004958   Baku City Circuit           flat/0deg/single              track            0     12  
Q17004958   Baku City Circuit           flat/90deg/single             track            0     12  
Q17004958   Baku City Circuit           coaster-flush-round/0deg/sing…base             0     16  
Q17004958   Baku City Circuit           coaster-flush-round/0deg/sing…track            0     14  
Q17004958   Baku City Circuit           coaster-raised-square/90deg/s…track            0     14  
Q171449     Watkins Glen International  flat/auto/single              track            0     42  
Q171449     Watkins Glen International  flat/0deg/single              track            0     34  
Q171449     Watkins Glen International  flat/90deg/single             track            0     48  
Q171449     Watkins Glen International  coaster-flush-round/0deg/sing…base             0    100  
Q171449     Watkins Glen International  coaster-flush-round/0deg/sing…track            0     50  
Q171449     Watkins Glen International  coaster-raised-square/90deg/s…track            0     32  
Q171449     Watkins Glen International  flat/auto/combined            secondary     1896      0  (38.5063,60.3656,5.5)->(38.5435,59.083,5.5)
Q171449     Watkins Glen International  flat/auto/combined            track            0     42  
Q171449     Watkins Glen International  coaster-flush-round/0deg/comb…base             0    100  
Q171449     Watkins Glen International  coaster-flush-round/0deg/comb…secondary     1896      0  (14.2969,-11.625,2.5)->(13.2973,-11.654,2.5)
Q171449     Watkins Glen International  coaster-flush-round/0deg/comb…track            0     50  
Q172884     Jerez-Ángel Nieto Circuit   flat/auto/single              track            0     24  
Q172884     Jerez-Ángel Nieto Circuit   flat/0deg/single              track            0     22  
Q172884     Jerez-Ángel Nieto Circuit   flat/90deg/single             track            0     24  
Q172884     Jerez-Ángel Nieto Circuit   coaster-flush-round/0deg/sing…base             0     33  
Q172884     Jerez-Ángel Nieto Circuit   coaster-flush-round/0deg/sing…track            0     26  
Q172884     Jerez-Ángel Nieto Circuit   coaster-raised-square/90deg/s…track            0     24  
Q1738522    Kemora Circuit              flat/auto/single              track            0      2  
Q1738522    Kemora Circuit              flat/0deg/single              track            0      2  
Q1738522    Kemora Circuit              flat/90deg/single             track            0      4  
Q1738522    Kemora Circuit              coaster-flush-round/0deg/sing…base             0      4  
Q1738522    Kemora Circuit              coaster-raised-square/90deg/s…track            0      4  
Q18680802   Kymi Ring                   flat/auto/single              track            0     24  
Q18680802   Kymi Ring                   flat/0deg/single              track            0     24  
Q18680802   Kymi Ring                   flat/90deg/single             track            0     18  
Q18680802   Kymi Ring                   coaster-flush-round/0deg/sing…base             0     15  
Q18680802   Kymi Ring                   coaster-flush-round/0deg/sing…track            0     20  
Q18680802   Kymi Ring                   coaster-raised-square/90deg/s…track            0     26  
Q20022006   Autódromo Ciudad de La Riojaflat/auto/single              track            0      6  
Q20022006   Autódromo Ciudad de La Riojaflat/0deg/single              track            0     16  
Q20022006   Autódromo Ciudad de La Riojaflat/90deg/single             track            0     22  
Q20022006   Autódromo Ciudad de La Riojacoaster-flush-round/0deg/sing…base             0      9  
Q20022006   Autódromo Ciudad de La Riojacoaster-flush-round/0deg/sing…track            0     18  
Q20022006   Autódromo Ciudad de La Riojacoaster-raised-square/90deg/s…track            0     16  
Q222686     Masaryk Circuit             flat/auto/single              track            0     20  
Q222686     Masaryk Circuit             flat/0deg/single              track            0     22  
Q222686     Masaryk Circuit             flat/90deg/single             track            0      6  
Q222686     Masaryk Circuit             coaster-flush-round/0deg/sing…base             0     10  
Q222686     Masaryk Circuit             coaster-flush-round/0deg/sing…track            0     14  
Q222686     Masaryk Circuit             coaster-raised-square/90deg/s…track            0     12  
Q2630372    Top Gear test track         flat/auto/single              track            0      8  
Q2630372    Top Gear test track         flat/0deg/single              track            0      8  
Q2630372    Top Gear test track         flat/90deg/single             track            0      6  
Q2630372    Top Gear test track         coaster-flush-round/0deg/sing…base             0      6  
Q2630372    Top Gear test track         coaster-flush-round/0deg/sing…track            0      6  
Q2630372    Top Gear test track         coaster-raised-square/90deg/s…track            0      6  
Q29035351   Freedom Factory             flat/auto/single              track            0     36  
Q29035351   Freedom Factory             flat/0deg/single              track            0     94  
Q29035351   Freedom Factory             flat/90deg/single             track            0     36  
Q29035351   Freedom Factory             coaster-flush-round/0deg/sing…base             4     16  (34.9905,-2.3076,2.5)->(33.1318,-2.3076,2.5)
Q29035351   Freedom Factory             coaster-flush-round/0deg/sing…track            0     22  
Q29035351   Freedom Factory             coaster-raised-square/90deg/s…track            0     24  
Q3208132    Penbay International Circuitflat/auto/single              track            0     46  
Q3208132    Penbay International Circuitflat/0deg/single              track            0     52  
Q3208132    Penbay International Circuitflat/90deg/single             track            0     46  
Q3208132    Penbay International Circuitcoaster-flush-round/0deg/sing…base             0     49  
Q3208132    Penbay International Circuitcoaster-flush-round/0deg/sing…track            0     34  
Q3208132    Penbay International Circuitcoaster-raised-square/90deg/s…track            0     32  
Q390103     Reem International Circuit  flat/auto/single              track            0     18  
Q390103     Reem International Circuit  flat/0deg/single              track            0     50  
Q390103     Reem International Circuit  flat/90deg/single             track            0     22  
Q390103     Reem International Circuit  coaster-flush-round/0deg/sing…base             0     78  
Q390103     Reem International Circuit  coaster-flush-round/0deg/sing…track            0     48  
Q390103     Reem International Circuit  coaster-raised-square/90deg/s…track            0     22  
Q4827211    Autódromo Chiapas           flat/auto/single              track            0      2  
Q4827211    Autódromo Chiapas           flat/0deg/single              track            0      4  
Q4827211    Autódromo Chiapas           flat/90deg/single             track            0      2  
Q4827211    Autódromo Chiapas           coaster-flush-round/0deg/sing…base             8     25  (-22.7398,-33.5302,2.5)->(-23.5086,-33.5302,2.5)
Q4827211    Autódromo Chiapas           coaster-flush-round/0deg/sing…track            0     20  
Q4827211    Autódromo Chiapas           coaster-raised-square/90deg/s…track            0     12  
Q4827237    Autódromo Potosino          flat/auto/single              track            0      8  
Q4827237    Autódromo Potosino          flat/0deg/single              track            0      8  
Q4827237    Autódromo Potosino          flat/90deg/single             track            0     10  
Q4827237    Autódromo Potosino          coaster-flush-round/0deg/sing…base             0      7  
Q4827237    Autódromo Potosino          coaster-flush-round/0deg/sing…track            0     12  
Q4827237    Autódromo Potosino          coaster-raised-square/90deg/s…track            0     16  
Q4879200    Bedford Speedway            flat/auto/single              track            0     18  
Q4879200    Bedford Speedway            flat/0deg/single              track            0     18  
Q4879200    Bedford Speedway            flat/90deg/single             track            0     18  
Q4879200    Bedford Speedway            coaster-flush-round/0deg/sing…base             0     21  
Q4879200    Bedford Speedway            coaster-flush-round/0deg/sing…track            0     18  
Q4879200    Bedford Speedway            coaster-raised-square/90deg/s…track            0     14  
Q5121627    Circuito Rosendo Hernández  flat/auto/single              track            0     26  
Q5121627    Circuito Rosendo Hernández  flat/0deg/single              track            0     16  
Q5121627    Circuito Rosendo Hernández  flat/90deg/single             track            0     24  
Q5121627    Circuito Rosendo Hernández  coaster-flush-round/0deg/sing…base             0     42  
Q5121627    Circuito Rosendo Hernández  coaster-flush-round/0deg/sing…track            0     30  
Q5121627    Circuito Rosendo Hernández  coaster-raised-square/90deg/s…track            0     36  
Q5457795    Flat Rock Speedway          flat/auto/single              track            0      8  
Q5457795    Flat Rock Speedway          flat/0deg/single              track            0     10  
Q5457795    Flat Rock Speedway          flat/90deg/single             track            0      8  
Q5457795    Flat Rock Speedway          coaster-flush-round/0deg/sing…base             0     17  
Q5457795    Flat Rock Speedway          coaster-flush-round/0deg/sing…track            0     12  
Q5457795    Flat Rock Speedway          coaster-raised-square/90deg/s…track            0      8  
Q5713001    Autódromo La Chutana        flat/auto/single              track            0      4  
Q5713001    Autódromo La Chutana        flat/0deg/single              track            0      4  
Q5713001    Autódromo La Chutana        flat/90deg/single             track            0     10  
Q5713001    Autódromo La Chutana        coaster-flush-round/0deg/sing…base             9     28  (-6.6029,-44.5129,2.5)->(19.9463,-40.8184,2.5)
Q5713001    Autódromo La Chutana        coaster-flush-round/0deg/sing…track            0     20  
Q5713001    Autódromo La Chutana        coaster-raised-square/90deg/s…track            0     10  
Q5967569    I-70 Speedway               flat/auto/single              track            0     10  
Q5967569    I-70 Speedway               flat/0deg/single              track            0     10  
Q5967569    I-70 Speedway               flat/90deg/single             track            0     12  
Q5967569    I-70 Speedway               coaster-flush-round/0deg/sing…base             0      6  
Q5967569    I-70 Speedway               coaster-flush-round/0deg/sing…track            0      8  
Q5967569    I-70 Speedway               coaster-raised-square/90deg/s…track            0      8  
Q648512     Road America                flat/auto/single              track            0      2  
Q648512     Road America                flat/90deg/single             track            0      4  
Q648512     Road America                coaster-flush-round/0deg/sing…base             0     19  
Q648512     Road America                coaster-flush-round/0deg/sing…track            0     22  
Q648512     Road America                coaster-raised-square/90deg/s…track            0      2  
Q6918074    Motopark Raceway            flat/auto/single              track            0     10  
Q6918074    Motopark Raceway            flat/0deg/single              track            0     10  
Q6918074    Motopark Raceway            flat/90deg/single             track            0     16  
Q6918074    Motopark Raceway            coaster-flush-round/0deg/sing…base             0     11  
Q6918074    Motopark Raceway            coaster-flush-round/0deg/sing…track            0     10  
Q6918074    Motopark Raceway            coaster-raised-square/90deg/s…track            0     10  
Q7170876    Perth Motorplex             flat/auto/single              track            0     10  
Q7170876    Perth Motorplex             flat/0deg/single              track            0     16  
Q7170876    Perth Motorplex             flat/90deg/single             track            0     16  
Q7170876    Perth Motorplex             coaster-flush-round/0deg/sing…base             0     14  
Q7170876    Perth Motorplex             coaster-flush-round/0deg/sing…track            0     16  
Q7170876    Perth Motorplex             coaster-raised-square/90deg/s…track            0     12  
Q7570163    Southern National Motorspor…flat/auto/single              track            0     32  
Q7570163    Southern National Motorspor…flat/0deg/single              track            0     32  
Q7570163    Southern National Motorspor…flat/90deg/single             track            0     40  
Q7570163    Southern National Motorspor…coaster-flush-round/0deg/sing…base             0     39  
Q7570163    Southern National Motorspor…coaster-flush-round/0deg/sing…track            0     40  
Q7570163    Southern National Motorspor…coaster-raised-square/90deg/s…track            0     46  
Q786639     Caesar's Palace Circuit     flat/auto/single              track            0      6  
Q786639     Caesar's Palace Circuit     flat/0deg/single              track            0      2  
Q786639     Caesar's Palace Circuit     flat/90deg/single             track            0      6  
Q786639     Caesar's Palace Circuit     coaster-flush-round/0deg/sing…base             0     26  
Q786639     Caesar's Palace Circuit     coaster-flush-round/0deg/sing…track            0     16  
Q786639     Caesar's Palace Circuit     coaster-raised-square/90deg/s…track            0     10  
Q813859     Bedford Autodrome           flat/auto/single              track            0      8  
Q813859     Bedford Autodrome           flat/0deg/single              track            0      4  
Q813859     Bedford Autodrome           flat/90deg/single             track            0      2  
Q813859     Bedford Autodrome           coaster-flush-round/0deg/sing…base             0     24  
Q813859     Bedford Autodrome           coaster-flush-round/0deg/sing…track            0     24  
Q813859     Bedford Autodrome           coaster-raised-square/90deg/s…track            0      4  
-----------------------------------------------------------------------------------------------------------
40 tracks built, 0 skipped (no geometry), 263 failures across 40 tracks (40 requested)
```

</details>

## Follow-up

Fixing the underlying mesh defects is tracked in #125.

Closes #122
