### PR TITLE
Validator: detect T-junctions (#109)

### DIFF
--- a/src/model/validate-mesh.ts
+++ b/src/model/validate-mesh.ts
@@ -12,9 +12,16 @@ import type { Triangle, TrackModel, Vertex } from '../types/model.js';
 import { splitModelTriangles } from './triangle-groups.js';
 
 /** 4-decimal quantization, matching `formatCoordinate` in src/export/threemf.ts. */
-const DEFAULT_PRECISION_MM = 1e-4;
+export const DEFAULT_PRECISION_MM = 1e-4;
 /** Triangles with cross-product magnitude below this (in mm²) are considered degenerate. */
 const DEFAULT_AREA_TOLERANCE_MM2 = 1e-6;
+/**
+ * Perpendicular distance (mm) within which a vertex is treated as lying ON an
+ * edge for T-junction detection. Deliberately equal to `DEFAULT_PRECISION_MM`:
+ * a vertex is "on the line" exactly when it sits within one quantization grid
+ * step of the edge.
+ */
+export const DEFAULT_TJUNCTION_TOLERANCE_MM = 1e-4;
 
 function quantize(value: number, precision: number): number {
   return Math.round(value / precision) * precision;
@@ -48,6 +55,26 @@ export interface NonManifoldEdge {
 export interface ValidateOptions {
   precisionMm?: number;
   areaToleranceMm2?: number;
+  /** Perpendicular distance tolerance (mm) for T-junction detection. Defaults to
+   *  `DEFAULT_TJUNCTION_TOLERANCE_MM` (1e-4). */
+  toleranceMm?: number;
+}
+
+/**
+ * A T-junction: vertex `V` lying in the INTERIOR of an edge `(a,b)` of another
+ * triangle, sharing no endpoint topologically (quantized) with that edge. The
+ * mesh stays 2-manifold by edge-incidence count, so `findNonManifoldEdges`
+ * cannot see this, yet slicers (Bambu Studio / PrusaSlicer) flag it.
+ */
+export interface TJunction {
+  /** The interior vertex (raw coordinates). */
+  vertex: Vertex;
+  /** The edge whose interior `vertex` lies on (raw coordinates). */
+  edge: { a: Vertex; b: Vertex };
+  /** Index of the triangle that owns the offending edge. */
+  triangleIndex: number;
+  /** Perpendicular distance (mm) from `vertex` to the edge line. */
+  perpendicularDistance: number;
 }
 
 /**
@@ -118,11 +145,156 @@ export function findDegenerateTriangles(
   return result;
 }
 
+/** Edge record stored in the uniform XY grid for T-junction detection. */
+interface GridEdge {
+  a: Vertex;
+  b: Vertex;
+  qaKey: string;
+  qbKey: string;
+  triangleIndex: number;
+}
+
+/**
+ * Detects T-junctions: vertices lying in the interior of another triangle's edge.
+ *
+ * Backed by a uniform XY-plane grid spatial index. These meshes are prismatic
+ * (Z is a small set of discrete levels), so binning on XY is the discriminating
+ * axis. The `t` projection, perpendicular distance, and endpoint-radius math are
+ * all full 3D, so XY-only binning only OVER-collects candidates across Z levels;
+ * the 3D distance term rejects the over-collected cross-level pairs.
+ *
+ * Predicate — a vertex `V` is a T-junction of edge `(A,B)` iff ALL hold (identity
+ * tests use quantized coords; the t/distance/radius math uses raw coords):
+ *  - quantized-key inequality `qV != qA` and `qV != qB` (no shared endpoint),
+ *  - absolute endpoint radius `|V-A| > precisionMm` and `|V-B| > precisionMm`,
+ *  - non-degenerate edge (`|B-A| > 0` after quantization),
+ *  - interior projection `t = dot(V-A, B-A)/dot(B-A, B-A)` strictly in `(0, 1)`,
+ *  - perpendicular distance `d = |(V-A) - t*(B-A)| <= toleranceMm`.
+ */
+export function findTJunctions(
+  triangles: Triangle[],
+  options: ValidateOptions = {},
+): TJunction[] {
+  const precision = options.precisionMm ?? DEFAULT_PRECISION_MM;
+  const tolerance = options.toleranceMm ?? DEFAULT_TJUNCTION_TOLERANCE_MM;
+  const cell = Math.max(tolerance, 0.5);
+
+  const cellKey = (cx: number, cy: number): string => `${cx},${cy}`;
+  const grid = new Map<string, GridEdge[]>();
+
+  // Unique representative raw vertex per quantized key (first seen).
+  const uniqueVertices = new Map<string, Vertex>();
+
+  // Deduplicate physical edges by quantized edge-key, keeping the lowest
+  // triangleIndex that owns the edge (so emission is deterministic).
+  const edges = new Map<string, GridEdge>();
+  for (let triIndex = 0; triIndex < triangles.length; triIndex += 1) {
+    const tri = triangles[triIndex]!;
+    const keys = tri.map(v => vertexKey(v, precision)) as [string, string, string];
+    for (let v = 0; v < 3; v += 1) {
+      if (!uniqueVertices.has(keys[v]!)) {
+        uniqueVertices.set(keys[v]!, tri[v]!);
+      }
+    }
+    for (let e = 0; e < 3; e += 1) {
+      const ka = keys[e]!;
+      const kb = keys[(e + 1) % 3]!;
+      if (ka === kb) {
+        continue; // degenerate edge — owned by findDegenerateTriangles
+      }
+      const ek = edgeKey(ka, kb);
+      if (!edges.has(ek)) {
+        edges.set(ek, { a: tri[e]!, b: tri[(e + 1) % 3]!, qaKey: ka, qbKey: kb, triangleIndex: triIndex });
+      }
+    }
+  }
+
+  // Insert each unique edge into every cell its tol-expanded XY bbox covers.
+  for (const record of edges.values()) {
+    const { a, b } = record;
+    const cx0 = Math.floor((Math.min(a.x, b.x) - tolerance) / cell);
+    const cx1 = Math.floor((Math.max(a.x, b.x) + tolerance) / cell);
+    const cy0 = Math.floor((Math.min(a.y, b.y) - tolerance) / cell);
+    const cy1 = Math.floor((Math.max(a.y, b.y) + tolerance) / cell);
+    for (let cx = cx0; cx <= cx1; cx += 1) {
+      for (let cy = cy0; cy <= cy1; cy += 1) {
+        const key = cellKey(cx, cy);
+        const bucket = grid.get(key);
+        if (bucket) {
+          bucket.push(record);
+        } else {
+          grid.set(key, [record]);
+        }
+      }
+    }
+  }
+
+  const tol2 = tolerance * tolerance;
+  const precision2 = precision * precision;
+  const emitted = new Set<string>();
+  const result: TJunction[] = [];
+
+  for (const [qV, V] of uniqueVertices) {
+    const cx = Math.floor(V.x / cell);
+    const cy = Math.floor(V.y / cell);
+    const bucket = grid.get(cellKey(cx, cy));
+    if (!bucket) {
+      continue;
+    }
+    for (const edge of bucket) {
+      if (qV === edge.qaKey || qV === edge.qbKey) {
+        continue; // shares an endpoint with the edge
+      }
+      const { a, b } = edge;
+      const bax = b.x - a.x, bay = b.y - a.y, baz = b.z - a.z;
+      const len2 = bax * bax + bay * bay + baz * baz;
+      if (len2 === 0) {
+        continue; // zero-length edge
+      }
+      const vax = V.x - a.x, vay = V.y - a.y, vaz = V.z - a.z;
+      // Absolute endpoint radius (raw 3D coords).
+      const distA2 = vax * vax + vay * vay + vaz * vaz;
+      if (distA2 <= precision2) {
+        continue;
+      }
+      const vbx = V.x - b.x, vby = V.y - b.y, vbz = V.z - b.z;
+      const distB2 = vbx * vbx + vby * vby + vbz * vbz;
+      if (distB2 <= precision2) {
+        continue;
+      }
+      const t = (vax * bax + vay * bay + vaz * baz) / len2;
+      if (!(t > 0 && t < 1)) {
+        continue; // not strictly interior
+      }
+      const px = vax - t * bax, py = vay - t * bay, pz = vaz - t * baz;
+      const d2 = px * px + py * py + pz * pz;
+      if (d2 > tol2) {
+        continue;
+      }
+      const ek = edgeKey(edge.qaKey, edge.qbKey);
+      const pairKey = `${qV}#${ek}`;
+      if (emitted.has(pairKey)) {
+        continue;
+      }
+      emitted.add(pairKey);
+      result.push({
+        vertex: V,
+        edge: { a, b },
+        triangleIndex: edge.triangleIndex,
+        perpendicularDistance: Math.sqrt(d2),
+      });
+    }
+  }
+
+  return result;
+}
+
 export interface MeshSummary {
   triangleCount: number;
   uniqueVertexCount: number;
   nonManifoldEdgeCount: number;
   degenerateTriangleCount: number;
+  tJunctionCount: number;
 }
 
 export function summarizeMesh(triangles: Triangle[], options: ValidateOptions = {}): MeshSummary {
@@ -138,6 +310,7 @@ export function summarizeMesh(triangles: Triangle[], options: ValidateOptions = 
     uniqueVertexCount: uniqueVertices.size,
     nonManifoldEdgeCount: findNonManifoldEdges(triangles, options).length,
     degenerateTriangleCount: findDegenerateTriangles(triangles, options).length,
+    tJunctionCount: findTJunctions(triangles, options).length,
   };
 }
 
@@ -147,16 +320,18 @@ export interface PartReport {
   triangleCount: number;
   nonManifoldEdges: NonManifoldEdge[];
   degenerateTriangles: number[];
-  // Extended as #109 / #115 land — additive only, never removing the above:
-  // tJunctions: TJunction[];
+  /** T-junctions (#109): interior-of-edge vertices. NOT folded into `ModelReport.ok`. */
+  tJunctions: TJunction[];
+  // Extended as #115 lands — additive only, never removing the above:
   // flippedFaces: number[];
   // selfIntersections: SelfIntersection[];
   // shellComponents: number;
 }
 
 export interface ModelReport {
-  /** True iff every part is 2-manifold AND free of degenerate triangles. Pure data report; the
-   *  decision of what to ASSERT on lives in the test helper's `failOn`, not here. */
+  /** True iff every part is 2-manifold AND free of degenerate triangles. T-junctions (#109) are
+   *  deliberately NOT folded in — they are a separate measurement consumed via the test helper's
+   *  `failOn`. Pure data report; the decision of what to ASSERT on lives in the test helper, not here. */
   ok: boolean;
   parts: PartReport[];
 }
@@ -182,6 +357,7 @@ export function validateModel(
     triangleCount: triangles.length,
     nonManifoldEdges: findNonManifoldEdges(triangles, options),
     degenerateTriangles: findDegenerateTriangles(triangles, options),
+    tJunctions: findTJunctions(triangles, options),
   });
 
   const parts: PartReport[] = [

--- a/test-utils/mesh-assertions.ts
+++ b/test-utils/mesh-assertions.ts
@@ -21,16 +21,22 @@ const PART_LABELS: Record<PartReport['part'], string> = {
  * `failOn` selects the failure CONDITION:
  *   - `'edges+degenerates'` (default): fail on non-manifold edges OR degenerate triangles.
  *   - `'edges'`: fail ONLY on non-manifold edges.
+ *   - `'edges+tjunctions'`: fail on non-manifold edges OR T-junctions (#109).
+ *   - `'edges+degenerates+tjunctions'`: fail on any of the three.
  *
- * Degenerate diagnostics are PRINTED in the failure message in both modes; printing
- * is not failing.
+ * Degenerate and T-junction diagnostics are PRINTED in the failure message regardless
+ * of `failOn`; printing is not failing.
  */
+type FailOn = 'edges' | 'edges+degenerates' | 'edges+tjunctions' | 'edges+degenerates+tjunctions';
+
 export function assertModelManifold(
   label: string,
   model: TrackModel,
-  options?: { failOn?: 'edges' | 'edges+degenerates' } & ValidateOptions,
+  options?: { failOn?: FailOn } & ValidateOptions,
 ): void {
   const { failOn = 'edges+degenerates', ...validateOptions } = options ?? {};
+  const failOnDegenerates = failOn === 'edges+degenerates' || failOn === 'edges+degenerates+tjunctions';
+  const failOnTJunctions = failOn === 'edges+tjunctions' || failOn === 'edges+degenerates+tjunctions';
   const report = validateModel(model, validateOptions);
   const groups = splitModelTriangles(model);
   const trianglesByPart: Record<PartReport['part'], Triangle[]> = {
@@ -46,7 +52,8 @@ export function assertModelManifold(
 
     const failed =
       part.nonManifoldEdges.length > 0 ||
-      (failOn === 'edges+degenerates' && part.degenerateTriangles.length > 0);
+      (failOnDegenerates && part.degenerateTriangles.length > 0) ||
+      (failOnTJunctions && part.tJunctions.length > 0);
 
     if (!failed) {
       continue;
@@ -59,8 +66,17 @@ export function assertModelManifold(
       b: { x: +e.b.x.toFixed(4), y: +e.b.y.toFixed(4), z: +e.b.z.toFixed(4) },
       triangleIndices: e.triangleIndices,
     }));
+    const tJunctionExamples = part.tJunctions.slice(0, 10).map(t => ({
+      vertex: { x: +t.vertex.x.toFixed(4), y: +t.vertex.y.toFixed(4), z: +t.vertex.z.toFixed(4) },
+      edge: {
+        a: { x: +t.edge.a.x.toFixed(4), y: +t.edge.a.y.toFixed(4), z: +t.edge.a.z.toFixed(4) },
+        b: { x: +t.edge.b.x.toFixed(4), y: +t.edge.b.y.toFixed(4), z: +t.edge.b.z.toFixed(4) },
+      },
+      triangleIndex: t.triangleIndex,
+      perpendicularDistance: +t.perpendicularDistance.toFixed(6),
+    }));
     assert.fail(
-      `${partLabel}: part is not 2-manifold\n  summary=${JSON.stringify(summary)}\n  first non-manifold edges: ${JSON.stringify(examples, null, 2)}\n  degenerate triangle indices (first 5): ${JSON.stringify(part.degenerateTriangles.slice(0, 5))}`,
+      `${partLabel}: part failed mesh validation (failOn=${failOn})\n  summary=${JSON.stringify(summary)}\n  first non-manifold edges: ${JSON.stringify(examples, null, 2)}\n  degenerate triangle indices (first 5): ${JSON.stringify(part.degenerateTriangles.slice(0, 5))}\n  T-junction count: ${part.tJunctions.length}\n  first T-junctions (vertex / edge / perpendicularDistance): ${JSON.stringify(tJunctionExamples, null, 2)}`,
     );
   }
 }

--- a/test/threemf-manifold-spa.test.ts
+++ b/test/threemf-manifold-spa.test.ts
@@ -42,5 +42,5 @@ test('Spa-Francorchamps flush coaster — each 3MF object is 2-manifold', () => 
     coasterInlay: 'flush',
     primaryOrientationDeg: 'auto',
   });
-  assertModelManifold('Spa flush', model, { failOn: 'edges' });
+  assertModelManifold('Spa flush', model, { failOn: 'edges+tjunctions' });
 });

--- a/test/threemf-manifold.test.ts
+++ b/test/threemf-manifold.test.ts
@@ -80,5 +80,5 @@ test('coaster round + raised export is 2-manifold per part (Spa repro mode)', ()
 
 test('coaster round + flush export is 2-manifold per part', () => {
   const model = buildModelForCase({ coasterMode: true, coasterInlay: 'flush' });
-  assertModelManifold('coaster flush', model);
+  assertModelManifold('coaster flush', model, { failOn: 'edges+tjunctions' });
 });

--- a/test/validate-model.test.ts
+++ b/test/validate-model.test.ts
@@ -65,6 +65,14 @@ test('validateModel includes empty parts with zero findings that never break ok'
   assert.equal(secondary.triangleCount, 0);
   assert.deepEqual(secondary.nonManifoldEdges, []);
   assert.deepEqual(secondary.degenerateTriangles, []);
+  assert.deepEqual(secondary.tJunctions, []);
+});
+
+test('validateModel reports a tJunctions array on every part', () => {
+  const report = validateModel(buildModel());
+  for (const part of report.parts) {
+    assert.ok(Array.isArray(part.tJunctions), `${part.part} has a tJunctions array`);
+  }
 });
 
 test('validateModel.ok is true iff every part has zero non-manifold edges and degenerates', () => {

--- a/test/validate-tjunctions.test.ts
+++ b/test/validate-tjunctions.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Synthetic unit tests for `findTJunctions` — the T-junction detector (#109).
+ *
+ * A T-junction is a vertex lying in the INTERIOR of another triangle's edge while
+ * sharing no endpoint topologically with that edge. The mesh stays 2-manifold by
+ * edge-incidence count, so `findNonManifoldEdges` cannot see it.
+ */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { findTJunctions, DEFAULT_PRECISION_MM, DEFAULT_TJUNCTION_TOLERANCE_MM } from '../src/model/validate-mesh.js';
+import type { Triangle, Vertex } from '../src/types/model.js';
+
+const v = (x: number, y: number, z = 0): Vertex => ({ x, y, z });
+
+test('detects a vertex sitting exactly mid-edge of another triangle', () => {
+  // Triangle 0 owns the long edge A=(0,0,0) -> B=(10,0,0).
+  const longEdgeTri: Triangle = [v(0, 0), v(10, 0), v(5, 5)];
+  // Triangle 1 has a vertex V=(5,0,0) exactly on the long edge's interior.
+  const touchingTri: Triangle = [v(5, 0), v(2, -4), v(8, -4)];
+
+  const result = findTJunctions([longEdgeTri, touchingTri]);
+  assert.equal(result.length, 1);
+  const tj = result[0]!;
+  assert.equal(tj.triangleIndex, 0, 'reports the triangle owning the offending edge');
+  assert.ok(tj.perpendicularDistance < 1e-9, 'vertex lies on the line');
+  assert.deepEqual(tj.vertex, { x: 5, y: 0, z: 0 });
+  // Edge endpoints are A/B of the long edge (order-independent).
+  const xs = [tj.edge.a.x, tj.edge.b.x].sort((p, q) => p - q);
+  assert.deepEqual(xs, [0, 10]);
+});
+
+test('returns [] for a clean triangle fan (all shared endpoints, no interior incidence)', () => {
+  // Fan around a shared centre — every outer vertex is a true shared endpoint.
+  const c = v(0, 0);
+  const ring = [v(10, 0), v(7, 7), v(0, 10), v(-7, 7), v(-10, 0), v(-7, -7), v(0, -10), v(7, -7)];
+  const fan: Triangle[] = [];
+  for (let i = 0; i < ring.length; i += 1) {
+    fan.push([c, ring[i]!, ring[(i + 1) % ring.length]!]);
+  }
+  assert.deepEqual(findTJunctions(fan), []);
+});
+
+test('excludes a sub-precision near-endpoint vertex via the absolute endpoint radius', () => {
+  // Edge A=(0,0,0) -> B=(10,0,0). Place V offset from A by precisionMm/2 ALONG the edge.
+  // This sub-grid offset can quantize to a key different from qA, so the key inequality
+  // would let it through; the absolute |V-A| > precisionMm radius must REJECT it.
+  const offset = DEFAULT_PRECISION_MM / 2;
+  const longEdgeTri: Triangle = [v(0, 0), v(10, 0), v(5, 5)];
+  const nearEndpointTri: Triangle = [v(offset, 0), v(2, -4), v(8, -4)];
+
+  const result = findTJunctions([longEdgeTri, nearEndpointTri]);
+  assert.deepEqual(result, [], 'near-endpoint duplicate is not a T-junction');
+});
+
+test('tolerance boundary at 1e-4: just-above rejected, just-below reported', () => {
+  const longEdgeTri: Triangle = [v(0, 0), v(10, 0), v(5, 5)];
+
+  // Vertex perpendicular-offset just ABOVE tolerance — not reported.
+  const above = DEFAULT_TJUNCTION_TOLERANCE_MM * 1.5;
+  const aboveTri: Triangle = [v(5, above), v(2, -4), v(8, -4)];
+  assert.deepEqual(findTJunctions([longEdgeTri, aboveTri]), [], 'd just above tolerance is rejected');
+
+  // Vertex perpendicular-offset just BELOW tolerance — reported.
+  const below = DEFAULT_TJUNCTION_TOLERANCE_MM * 0.5;
+  const belowTri: Triangle = [v(5, below), v(2, -4), v(8, -4)];
+  const reported = findTJunctions([longEdgeTri, belowTri]);
+  assert.equal(reported.length, 1, 'd just below tolerance is reported');
+  assert.ok(reported[0]!.perpendicularDistance <= DEFAULT_TJUNCTION_TOLERANCE_MM);
+});
+
+test('does not report a strictly t<=0 or t>=1 projection (beyond the segment)', () => {
+  // Vertex collinear with the edge but PAST endpoint B (t > 1): not interior.
+  const longEdgeTri: Triangle = [v(0, 0), v(10, 0), v(5, 5)];
+  const beyondTri: Triangle = [v(15, 0), v(12, -4), v(18, -4)];
+  assert.deepEqual(findTJunctions([longEdgeTri, beyondTri]), []);
+});


### PR DESCRIPTION
## Summary

Adds a **T-junction detector** to the mesh validator. A T-junction is a vertex lying in the INTERIOR of another triangle's edge while sharing no endpoint topologically with that edge. The mesh stays strictly 2-manifold by edge-incidence count, so the existing findNonManifoldEdges cannot see it, yet Bambu Studio / PrusaSlicer flag it. This is the prerequisite MEASUREMENT tool for the downstream geometry fixes (#110 flush-text, #111 simplifyRing) -- it does NOT fix any geometry itself.

## What changed

- src/model/validate-mesh.ts: new TJunction interface + findTJunctions(triangles, options?), backed by a mandatory uniform XY-grid spatial index (expand-on-insert into all tol-covered cells, own-cell query, full-3D distance filter). Predicate: strict t in (0,1); endpoint exclusion via quantized-key inequality AND absolute precisionMm radius; perpendicular distance <= toleranceMm with DEFAULT_TJUNCTION_TOLERANCE_MM = 1e-4. Added tJunctions to PartReport (filled the reserved slot, additive only), tJunctionCount to MeshSummary + summarizeMesh, computed per-part in validateModel. validateModel.ok is deliberately left FREE of T-junctions.
- test-utils/mesh-assertions.ts: extended assertModelManifold failOn with edges+tjunctions / edges+degenerates+tjunctions, plus a useful failure dump (first 10 T-junctions: coords + perpendicular distances) for #110/#111 to consume.
- test/validate-tjunctions.test.ts (new): synthetic unit tests -- mid-edge detection, clean fan returns [], absolute-radius endpoint exclusion at precisionMm/2, tolerance boundary at 1e-4, and beyond-segment rejection.
- test/validate-model.test.ts: locks the new report shape (tJunctions present on every part, empty parts have []), ok still true on the clean synthetic model.
- test/threemf-manifold.test.ts and test/threemf-manifold-spa.test.ts: flush + Spa flush cases opt into the T-junction assertion.

## INTENTIONALLY RED baseline (by design -- not a regression)

The flush-text and Spa manifold tests are EXPECTED to go RED now that the T-junction assertion fires (8 on the synthetic flush base part, 194 on Spa). This mirrors the established intentional-red pattern in test/mesh-sweep-sample.test.ts. Both fail specifically on the T-junction assertion (nonManifoldEdgeCount = 0) with a clean coord/distance dump. #110/#111 will later drive these to zero. Reviewers/CI readers: do not flag these two as regressions.

All other previously-green tests stay green. mesh-sweep-sample remains red for its own pre-existing reason (partFailed is NOT extended to T-junctions in this PR).

## Verification

- npm run build GREEN.
- New unit tests pass (5/5).
- Changed files eslint-clean.
- Full suite: 180 tests, 177 pass, 3 fail (flush + Spa = intended new red; mesh-sweep-sample = pre-existing intentional red).

Approved plan: .claude/plans/issue-109-tjunctions.md

Part of #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)