### PR TITLE
test(mesh-sweep): hard-fail the #122 sweep on T-junctions (#109), refresh #125 baseline

### DIFF
--- a/scripts/validate-meshes.ts
+++ b/scripts/validate-meshes.ts
@@ -34,7 +34,7 @@ const USAGE = `Usage: npm run validate:meshes [-- <options>]
   --help           Show this message.
 
 Exits non-zero if any (track, mode, part) fails the current mesh detectors
-(non-manifold edges or degenerate triangles).`;
+(non-manifold edges, degenerate triangles, or T-junctions).`;
 
 interface ParsedArgs {
   help: boolean;

--- a/test-utils/mesh-sweep.ts
+++ b/test-utils/mesh-sweep.ts
@@ -11,12 +11,13 @@
  * Builds go through the worker/export path exactly as `src/workers/model.worker.ts`
  * does: `buildTrackModel({ outlinePoints: null, basePlate: null, ... })` derives the
  * real outline + base plate internally, then `validateModel()` (src/model/validate-mesh.ts,
- * from #121/#123) runs the current non-manifold + degenerate detectors on every part.
+ * from #121/#123) runs the current non-manifold, degenerate, and T-junction (#109)
+ * detectors on every part.
  *
  * The failure predicate and row formatter iterate `report.parts` generically, so the
- * #109 (T-junction) and #115 (self-intersection / flipped winding / disjoint shell)
- * detectors slot in later by extending `validateModel` / `PartReport` and adding one
- * line to `partFailed` + the formatter — no structural change here.
+ * #115 (self-intersection / flipped winding / disjoint shell) detectors slot in later by
+ * extending `validateModel` / `PartReport` and adding one line to `partFailed` + the
+ * formatter — no structural change here.
  */
 
 import { readFileSync, readdirSync } from 'node:fs';

--- a/test-utils/mesh-sweep.ts
+++ b/test-utils/mesh-sweep.ts
@@ -187,14 +187,19 @@ export interface SweepFailure {
   part: PartReport['part'] | 'build';
   nonManifoldEdges: number;
   degenerateTriangles: number;
+  tJunctions: number;
   /** From nonManifoldEdges[0], rounded to 4dp. */
   firstEdge?: { a: { x: number; y: number; z: number }; b: { x: number; y: number; z: number } };
   buildError?: string;
 }
 
-/** Failure predicate for a part — extend here when #109/#115 fields land on PartReport. */
+/** Failure predicate for a part — extend here when #115 fields land on PartReport. */
 function partFailed(part: PartReport): boolean {
-  return part.nonManifoldEdges.length > 0 || part.degenerateTriangles.length > 0;
+  return (
+    part.nonManifoldEdges.length > 0 ||
+    part.degenerateTriangles.length > 0 ||
+    part.tJunctions.length > 0
+  );
 }
 
 function round4(n: number): number {
@@ -251,6 +256,7 @@ export function sweepOne(file: PrebuiltTrackFile, mode: Mode): SweepFailure[] {
         part: part.part,
         nonManifoldEdges: part.nonManifoldEdges.length,
         degenerateTriangles: part.degenerateTriangles.length,
+        tJunctions: part.tJunctions.length,
         ...(first
           ? {
               firstEdge: {
@@ -272,6 +278,7 @@ export function sweepOne(file: PrebuiltTrackFile, mode: Mode): SweepFailure[] {
         part: 'build',
         nonManifoldEdges: 0,
         degenerateTriangles: 0,
+        tJunctions: 0,
         buildError: message,
       },
     ];
@@ -327,6 +334,7 @@ const COLS = {
   part: 10,
   nm: 8,
   degen: 7,
+  tjunc: 7,
 };
 
 function truncate(s: string, width: number): string {
@@ -357,6 +365,7 @@ export function formatFailureTable(result: SweepResult, tracksRequested: number)
     'part'.padEnd(COLS.part) +
     'nm-edges'.padStart(COLS.nm) +
     'degens'.padStart(COLS.degen) +
+    'tjunc'.padStart(COLS.tjunc) +
     '  first edge';
   lines.push(header);
   lines.push('-'.repeat(header.length));
@@ -369,6 +378,7 @@ export function formatFailureTable(result: SweepResult, tracksRequested: number)
         f.part.padEnd(COLS.part) +
         String(f.nonManifoldEdges).padStart(COLS.nm) +
         String(f.degenerateTriangles).padStart(COLS.degen) +
+        String(f.tJunctions).padStart(COLS.tjunc) +
         '  ' +
         formatFirstEdge(f),
     );

--- a/test/mesh-sweep-sample.test.ts
+++ b/test/mesh-sweep-sample.test.ts
@@ -3,7 +3,7 @@
  *
  * Runs the SHARED sweep core (`test-utils/mesh-sweep.ts`) — the same code path the
  * `npm run validate:meshes` CLI runs — over the committed `REPRESENTATIVE_SAMPLE`, and
- * asserts ZERO mesh failures (non-manifold edges / degenerate triangles) across the
+ * asserts ZERO mesh failures (non-manifold edges / degenerate triangles / T-junctions) across the
  * worker/export build path.
  *
  * INTENTIONALLY RED (owner decision): several representative tracks already fail the


### PR DESCRIPTION
## Summary

Wires the #109/#127 per-part T-junction detector into the #122 mesh-validation sweep (`test-utils/mesh-sweep.ts`) so the sweep now **hard-fails on T-junctions**, mirroring the `'edges+degenerates+tjunctions'` semantics already enforced by the committed manifold tests (`test-utils/mesh-assertions.ts`). Adds a `tjunc` column to the failure table.

**Measurement only** — no geometry/model changes. Five edits, all in `test-utils/mesh-sweep.ts`:

- `partFailed` now also returns true when `part.tJunctions.length > 0`.
- `SweepFailure` gains a `tJunctions: number` field, populated at both construction sites (success push: `part.tJunctions.length`; build-error catch row: `0`).
- `COLS` + `formatFailureTable` gain a `tjunc` column (header + per-row cell) beside `degens`.

## Failure-count jump (intentional)

The baseline was intentionally red and stays red; the gate just got stricter:

- **Sample** (`npm run validate:meshes`): **263 → 273** failing rows across 40 tracks. The **+10** comes entirely from parts that previously had zero non-manifold edges and zero degenerate triangles but do have T-junctions (the prior 263 still fail identically).
- **Full corpus** (`npm run validate:meshes -- --all`): **7465** failing rows across 649 tracks.

This increased red is **intentional** — it mirrors the existing manifold tests' hard-fail behaviour. No new defects were introduced; the sweep simply now counts a defect class (#109 T-junctions) it previously ignored.

## Tests

`test/mesh-sweep-sample.test.ts` is unchanged and stays intentionally red (it asserts zero baseline failures; its assert message now renders the `tjunc` column and the higher count). The only failing tests are the expected intentional reds: this sample sweep test plus the two flush/Spa manifold tests from #109.

## Issue tracking

Issue #125 was refreshed (not closed) with the new T-junction-inclusive baseline tables and headline totals; the underlying geometry defects remain and are tracked by #110/#111.

Refs #122 #125 #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
