### PR TITLE
fix(base-plate): simplifyRing colinearity threshold + cascade collapse (#111)

### DIFF
--- a/src/model/base-plate.ts
+++ b/src/model/base-plate.ts
@@ -186,6 +186,32 @@ function normalizeToCounterClockwise(ring: Point2D[]): Point2D[] {
  * triangles in earcut output.
  */
 const POCKET_RING_QUANTIZATION_MM = 1e-4;
+
+/**
+ * True when quantized vertex B=(bx,by) lies within 2×Q (perpendicular) of the
+ * segment A=(ax,ay)–C=(cx,cy), where Q = POCKET_RING_QUANTIZATION_MM = 1e-4 mm.
+ *
+ * `cross` equals base×height = |A–C| * perpDist exactly (it is twice the signed
+ * area of triangle (A,B,C)); the perpendicular distance of B from line A–C is
+ * |cross| / |A–C|. Comparing |cross| <= 2 * Q * |A–C| is therefore algebraically
+ * identical to perpDist <= 2 * Q — i.e. this drops B when it is within TWO grid
+ * units (2e-4 mm) of the chord, NOT one. The factor of 2 is a deliberate safety
+ * margin above the 1e-4 export grid: it collapses vertices sitting within ~1 grid
+ * unit of the line (e.g. the empirical Spa vertex at perpDist ≈ 1.03e-4 mm) before
+ * export quantization can land them exactly on the segment and create a T-junction.
+ * Multiplying through by |A–C| also avoids a division and the |A–C|=0 singularity.
+ */
+function isColinearUnderGrid(
+  ax: number, ay: number,
+  bx: number, by: number,
+  cx: number, cy: number,
+): boolean {
+  const cross = (bx - ax) * (cy - by) - (by - ay) * (cx - bx);
+  const segLength = Math.hypot(cx - ax, cy - ay);
+  const threshold = 2 * POCKET_RING_QUANTIZATION_MM * segLength;
+  return Math.abs(cross) <= threshold;
+}
+
 /**
  * Removes vertices that are colinear with their neighbours under the
  * 4-decimal quantization grid. Earcut emits zero-area sliver triangles
@@ -221,24 +247,39 @@ function simplifyRing(ring: Point2D[]): Point2D[] {
     return deduped;
   }
 
-  // Step 2: drop colinear interior vertices using cross-product on quantized
-  // coords. Tolerance is one quantization unit squared — anything below
-  // that lies on the line through its neighbours after dedup.
-  const out: Point2D[] = [];
-  for (let i = 0; i < deduped.length; i += 1) {
-    const prev = deduped[(i - 1 + deduped.length) % deduped.length]!;
-    const curr = deduped[i]!;
-    const next = deduped[(i + 1) % deduped.length]!;
-    const ax = q(prev.x), ay = q(prev.y);
-    const bx = q(curr.x), by = q(curr.y);
-    const cx = q(next.x), cy = q(next.y);
-    const cross = (bx - ax) * (cy - by) - (by - ay) * (cx - bx);
-    if (Math.abs(cross) <= POCKET_RING_QUANTIZATION_MM * POCKET_RING_QUANTIZATION_MM) {
-      continue;
+  // Step 2: drop colinear interior vertices, iterating until stable so that
+  // cascading collinearity (a vertex that only becomes colinear once its
+  // neighbour is dropped) is also removed. O(N^2) worst case; N is a few
+  // thousand at most, so this is cheap.
+  let working: Point2D[] = deduped;
+  for (;;) {
+    if (working.length < 3) {
+      return deduped; // never collapse below a triangle; fall back to deduped ring
     }
-    out.push(curr);
+    const next: Point2D[] = [];
+    let removedAny = false;
+    for (let i = 0; i < working.length; i += 1) {
+      const prev = working[(i - 1 + working.length) % working.length]!;
+      const curr = working[i]!;
+      const nxt = working[(i + 1) % working.length]!;
+      if (
+        isColinearUnderGrid(
+          q(prev.x), q(prev.y),
+          q(curr.x), q(curr.y),
+          q(nxt.x), q(nxt.y),
+        )
+      ) {
+        removedAny = true;
+        continue; // drop curr
+      }
+      next.push(curr);
+    }
+    if (!removedAny) {
+      break;
+    }
+    working = next;
   }
-  return out.length >= 3 ? out : deduped;
+  return working.length >= 3 ? working : deduped;
 }
 
 /**

--- a/test/threemf-manifold-spa.test.ts
+++ b/test/threemf-manifold-spa.test.ts
@@ -10,6 +10,7 @@
  */
 
 import test from 'node:test';
+import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -17,6 +18,7 @@ import { dirname, join } from 'node:path';
 import { buildBasePlate, buildTrackOutline } from '../src/geometry/outline.js';
 import { projectNodes } from '../src/geometry/projection.js';
 import { buildTrackModel } from '../src/model/index.js';
+import { validateModel } from '../src/model/validate-mesh.js';
 import { assertModelManifold } from '../test-utils/mesh-assertions.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -42,7 +44,20 @@ test('Spa-Francorchamps flush coaster — each 3MF object is 2-manifold', () => 
     coasterInlay: 'flush',
     primaryOrientationDeg: 'auto',
   });
+  // Machine-checked #111 ratchet: the Spa flush BASE part had 194 T-junctions before the
+  // simplifyRing colinearity fix. The fix (length-scaled threshold + iterate-until-stable
+  // collapse) must keep the base-part T-junction count strictly below that baseline. We use
+  // `<`, not `=== 0`, so the residual stays observable as the measurement input for #110.
+  const SPA_BASE_TJUNCTION_BASELINE = 194;
+  const report = validateModel(model);
+  const baseTJunctions = report.parts.find(p => p.part === 'base')!.tJunctions.length;
+  assert.ok(
+    baseTJunctions < SPA_BASE_TJUNCTION_BASELINE,
+    `Spa flush base-part T-junction count regressed: ${baseTJunctions} (baseline ${SPA_BASE_TJUNCTION_BASELINE}, must stay below)`,
+  );
+
   // Opted into the full #115 detector set; this is one of the 3 intentional pre-existing
-  // failures and the new detectors may make it louder (expected, not a regression).
+  // failures and the new detectors may make it louder (expected, not a regression). Kept so
+  // the printed `T-junction count: N` residual remains visible for #110's re-measurement.
   assertModelManifold('Spa flush', model, { failOn: 'all' });
 });


### PR DESCRIPTION
## What

Fixes two bugs in `simplifyRing` (`src/model/base-plate.ts`, introduced in #108) that left near-colinear pocket-ring vertices in coaster pocket boundaries. After the exporter's 1e-4 mm quantization those vertices land exactly on a neighbouring edge, producing T-junctions.

1. **Threshold** — replaced the too-tight `Q*Q` cross-product bound with a length-scaled `2 * POCKET_RING_QUANTIZATION_MM * |A-C|`, extracted into a private `isColinearUnderGrid(prev, curr, next)` helper. `cross` is base×height, so this is algebraically a perpendicular-distance test that drops B when it sits within 2 grid units of chord A–C. The factor of 2 is the committed safety margin above the export grid (the motivating Spa vertex sits at perpDist ≈ 1.03×Q, which a 1×Q threshold would miss).
2. **Cascading collapse** — replaced the single filter pass with an iterate-until-stable loop that rebuilds the `working` ring and reads neighbours from the rebuilt array each pass, so second-order colinear vertices (only colinear once a neighbour is dropped) are also removed. Guards `working.length < 3` by returning the deduped ring.

`simplifyRing`'s public signature `(ring: Point2D[]) => Point2D[]` and both call sites are unchanged.

## Why

These near-colinear vertices are the #108/#111 mechanism behind T-junctions on real-track pockets. Fixing the threshold and adding cascade removal eliminates the bulk of them before export quantization can mint T-junctions.

## T-junction count (Spa flush base part)

**BEFORE: 194 → AFTER: 26** (measured via `validateModel` / `findTJunctions` from `src/model/validate-mesh.ts`). This residual is the measurement input for #110, so the test ratchets with `<`, not `=== 0`, keeping the residual observable.

## Tests

Added a machine-checked regression assertion in `test/threemf-manifold-spa.test.ts` that computes the Spa flush base-part T-junction count and asserts it is strictly `< 194`. The existing `assertModelManifold(..., { failOn: 'all' })` print path is kept so the residual count stays visible in CI for #110's re-measurement. The Spa flush base remains an intentional pre-existing `failOn: 'all'` failure (self-intersections), unchanged by this PR.

Approved plan: `.claude/plans/issue-111-simplify-ring.md`

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)