### PR TITLE
fix(triangle-groups): throw instead of lossy Z-only split for counts-less models

### DIFF
--- a/src/model/triangle-groups.ts
+++ b/src/model/triangle-groups.ts
@@ -1,5 +1,4 @@
 import type { TrackModel, Triangle } from '../types/model.js';
-import { BASE_THICKNESS_MM } from './base-plate.js';
 
 interface SplitModelTriangles {
   baseTriangles: Triangle[];
@@ -20,28 +19,22 @@ export function splitModelTriangles(
 ): SplitModelTriangles {
   const triangles = model?.triangles ?? [];
 
-  if (hasExplicitTriangleSegments(model)) {
-    const baseEnd = model!.baseTriangleCount!;
-    const secCount = model!.secondaryTrackTriangleCount ?? 0;
-    const secondaryEnd = baseEnd + secCount;
-    // trackTriangles includes primary track + text (both rendered in the same red/primary colour).
-    return {
-      baseTriangles: triangles.slice(0, baseEnd),
-      secondaryTrackTriangles: triangles.slice(baseEnd, secondaryEnd),
-      trackTriangles: triangles.slice(secondaryEnd),
-    };
+  if (!hasExplicitTriangleSegments(model)) {
+    throw new Error(
+      'splitModelTriangles requires explicit triangle-segment counts ' +
+        '(baseTriangleCount/secondaryTrackTriangleCount/trackTriangleCount); ' +
+        'the legacy Z-only heuristic cannot recover secondary-track triangles. ' +
+        'Build the model via buildTrackModel.',
+    );
   }
 
-  const baseTriangles: Triangle[] = [];
-  const trackTriangles: Triangle[] = [];
-
-  for (const triangle of triangles) {
-    if (triangle.every(vertex => vertex.z <= BASE_THICKNESS_MM)) {
-      baseTriangles.push(triangle);
-    } else {
-      trackTriangles.push(triangle);
-    }
-  }
-
-  return { baseTriangles, secondaryTrackTriangles: [], trackTriangles };
+  const baseEnd = model!.baseTriangleCount!;
+  const secCount = model!.secondaryTrackTriangleCount ?? 0;
+  const secondaryEnd = baseEnd + secCount;
+  // trackTriangles includes primary track + text (both rendered in the same red/primary colour).
+  return {
+    baseTriangles: triangles.slice(0, baseEnd),
+    secondaryTrackTriangles: triangles.slice(baseEnd, secondaryEnd),
+    trackTriangles: triangles.slice(secondaryEnd),
+  };
 }

--- a/test/export3mf.test.ts
+++ b/test/export3mf.test.ts
@@ -135,6 +135,47 @@ test('export3mf colors base plate triangles black and track triangles red', asyn
   assert.ok(redTriangles.length > 0);
 });
 
+function triangleAtZ(z: number): [Vertex, Vertex, Vertex] {
+  return [
+    { x: 0, y: 0, z },
+    { x: 1, y: 0, z },
+    { x: 0, y: 1, z },
+  ];
+}
+
+test('splitModelTriangles throws when explicit triangle-segment counts are missing', () => {
+  const model = { triangles: [triangleAtZ(0), triangleAtZ(5)] };
+
+  assert.throws(
+    () => splitModelTriangles(model),
+    /explicit triangle-segment counts/,
+  );
+});
+
+test('splitModelTriangles splits by explicit counts, including a non-empty secondary group', () => {
+  const triangles = [
+    triangleAtZ(0), // base
+    triangleAtZ(0), // base
+    triangleAtZ(1), // secondary
+    triangleAtZ(2), // primary track
+    triangleAtZ(3), // text (folded into trackTriangles)
+  ];
+  const model = {
+    triangles,
+    baseTriangleCount: 2,
+    secondaryTrackTriangleCount: 1,
+    trackTriangleCount: 1,
+    textTriangleCount: 1,
+  };
+
+  const { baseTriangles, secondaryTrackTriangles, trackTriangles } = splitModelTriangles(model);
+
+  assert.deepEqual(baseTriangles, triangles.slice(0, 2));
+  assert.deepEqual(secondaryTrackTriangles, triangles.slice(2, 3));
+  assert.deepEqual(trackTriangles, triangles.slice(3));
+  assert.ok(secondaryTrackTriangles.length > 0);
+});
+
 test('splitModelTriangles keeps embossed text in the red track group', async () => {
   const outlinePoints = syntheticOutline();
   const basePlate = buildBasePlate(outlinePoints, 20);


### PR DESCRIPTION
`splitModelTriangles` previously fell back to a Z-only heuristic when a model lacked the explicit triangle-segment counts; that path was lossy for secondary tracks, silently returning an empty `secondaryTrackTriangles` group and misfiling those triangles. This replaces the fallback with a descriptive `Error` so misuse is caught immediately at the call site, and deletes the now-dead Z-only code (along with the unused `BASE_THICKNESS_MM` import). Production is unaffected because `buildTrackModel` always sets `baseTriangleCount`/`secondaryTrackTriangleCount`/`trackTriangleCount`; the valid explicit-counts path and the function signature are unchanged. Tests document the new contract: a counts-less model throws, and a model with counts splits correctly including a non-empty secondary group.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)