### PR TITLE
refactor(text): delete legacy text3d.ts shim, fold into src/text barrel (#137)

### DIFF
--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -76,6 +76,7 @@ src/
 │   ├── placement.ts         # computePlacementMask, findPlacementCandidates, computeRankedTextPlacements
 │   ├── scoring.ts           # SCORING_WEIGHTS, scoreTextFit, size window multiplier, clearance scoring
 │   ├── mesh.ts              # buildTextMeshFromRankedPlacements, contour triangulation
+│   ├── debug.ts            # Test-only __debug*/__*PerfCounters helpers (not part of public API)
 │   └── index.ts             # Public re-exports
 │
 ├── export/                  # Export serialization (pure, no DOM)
@@ -118,7 +119,6 @@ src/
 │   ├── geometry/            # Per-track JSON files keyed by Wikidata ID
 │   └── track-search-index.json
 │
-├── text3d.ts                # Legacy shim — re-exports from src/text/ modules (see Known Debt below)
 ├── track-loader.ts          # Orchestrates model rebuilds: reads stores, posts to model worker, writes results back
 ├── label-font-data.js       # Base64-encoded font (+ .d.ts)
 ├── entry.ts                 # App entry point — mounts Svelte App component
@@ -306,14 +306,14 @@ Vite uses esbuild for transpilation and Rollup for production bundling. Workers 
 
 ## Known debt
 
-- **`src/text3d.ts` shim** — 389-line re-export file bridging `src/model/` and `src/text/` modules. Three call sites still import from it (`model/orientation.ts`, `stores/options.ts`, `components/OptionsPanel.svelte`). These should be migrated to import directly from `src/text/` modules, after which the shim can be deleted.
+- _(none currently tracked)_ — The former legacy text re-export shim was removed in #137: production code now imports directly from the `src/text/index.ts` barrel, and its test-only debug helpers live in `src/text/debug.ts`.
 
 ## Hard rules
 
 - **No file over 300 lines.** Decompose along responsibility boundaries.
 - **No circular dependencies.** Enforced by ESLint `import/no-cycle`.
 - **No DOM access in pure modules.** Only `components/`, `preview/`, and `entry.ts` may touch the DOM.
-- **No `any` in new code.** Use `unknown` and narrow. Legacy `any` casts exist in `text3d.ts` and should be eliminated when the shim is removed.
+- **No `any` in new code.** Use `unknown` and narrow. (The legacy `any` casts in the old text re-export shim were eliminated in #137; `src/text/debug.ts` is `any`-free.)
 - **Exports are the public API.** Each directory's `index.ts` defines what is public. Internal helpers are not re-exported.
 - **Workers own their computation.** The main thread must not call `buildTrackModel` directly — only via the model worker client. Same for export serialization.
 - **Build scripts stay in JS/MJS.** `scripts/` does not need TypeScript.

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -22,7 +22,7 @@ Both `npm test` and `npm run build` must pass before committing.
 | `test/geometry.test.js` | Geometry projection and outline building |
 | `test/model.test.js` | 3D model construction |
 | `test/export3mf.test.js` | 3MF export format |
-| `test/text3d.test.js` | Track name text rendering |
+| `test/text-placement.test.ts` | Track name text rendering |
 | `test/track-name.test.js` | Track name selection logic |
 | `test/picker.test.js` | Layout picker ranking |
 | `test/preview-geometry.test.js` | Preview geometry generation |

--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -76,6 +76,7 @@ src/
 │   ├── placement.ts         # computePlacementMask, findPlacementCandidates, computeRankedTextPlacements
 │   ├── scoring.ts           # SCORING_WEIGHTS, scoreTextFit, size window multiplier, clearance scoring
 │   ├── mesh.ts              # buildTextMeshFromRankedPlacements, contour triangulation
+│   ├── debug.ts            # Test-only __debug*/__*PerfCounters helpers (not part of public API)
 │   └── index.ts             # Public re-exports
 │
 ├── export/                  # Export serialization (pure, no DOM)
@@ -118,7 +119,6 @@ src/
 │   ├── geometry/            # Per-track JSON files keyed by Wikidata ID
 │   └── track-search-index.json
 │
-├── text3d.ts                # Legacy shim — re-exports from src/text/ modules (see Known Debt below)
 ├── track-loader.ts          # Orchestrates model rebuilds: reads stores, posts to model worker, writes results back
 ├── label-font-data.js       # Base64-encoded font (+ .d.ts)
 ├── entry.ts                 # App entry point — mounts Svelte App component
@@ -306,14 +306,14 @@ Vite uses esbuild for transpilation and Rollup for production bundling. Workers 
 
 ## Known debt
 
-- **`src/text3d.ts` shim** — 389-line re-export file bridging `src/model/` and `src/text/` modules. Three call sites still import from it (`model/orientation.ts`, `stores/options.ts`, `components/OptionsPanel.svelte`). These should be migrated to import directly from `src/text/` modules, after which the shim can be deleted.
+- _(none currently tracked)_ — The former legacy text re-export shim was removed in #137: production code now imports directly from the `src/text/index.ts` barrel, and its test-only debug helpers live in `src/text/debug.ts`.
 
 ## Hard rules
 
 - **No file over 300 lines.** Decompose along responsibility boundaries.
 - **No circular dependencies.** Enforced by ESLint `import/no-cycle`.
 - **No DOM access in pure modules.** Only `components/`, `preview/`, and `entry.ts` may touch the DOM.
-- **No `any` in new code.** Use `unknown` and narrow. Legacy `any` casts exist in `text3d.ts` and should be eliminated when the shim is removed.
+- **No `any` in new code.** Use `unknown` and narrow. (The legacy `any` casts in the old text re-export shim were eliminated in #137; `src/text/debug.ts` is `any`-free.)
 - **Exports are the public API.** Each directory's `index.ts` defines what is public. Internal helpers are not re-exported.
 - **Workers own their computation.** The main thread must not call `buildTrackModel` directly — only via the model worker client. Same for export serialization.
 - **Build scripts stay in JS/MJS.** `scripts/` does not need TypeScript.

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -22,7 +22,7 @@ Both `npm test` and `npm run build` must pass before committing.
 | `test/geometry.test.js` | Geometry projection and outline building |
 | `test/model.test.js` | 3D model construction |
 | `test/export3mf.test.js` | 3MF export format |
-| `test/text3d.test.js` | Track name text rendering |
+| `test/text-placement.test.ts` | Track name text rendering |
 | `test/track-name.test.js` | Track name selection logic |
 | `test/picker.test.js` | Layout picker ranking |
 | `test/preview-geometry.test.js` | Preview geometry generation |

--- a/docs/text-placement-research.md
+++ b/docs/text-placement-research.md
@@ -2,7 +2,7 @@
 
 > **App context:** Fully client-side, browser-only, must remain fast on phones/iPhone Safari.  
 > **Use case:** Place embossed circuit-name text on the base plate in the largest visually appropriate empty rectangular area, avoiding the track outline and other no-go zones.  
-> **Current state:** `src/text3d.js` chooses either the bounding box of the largest infield hole or a small fallback strip near the base edge, then scales a single-line string to fit.
+> **Current state:** `src/text/placement.ts` chooses either the bounding box of the largest infield hole or a small fallback strip near the base edge, then scales a single-line string to fit.
 
 ---
 
@@ -70,7 +70,7 @@ From the current code:
   - builds the base plate mesh
   - builds the track mesh
   - calls `buildTextMesh(trackName, outlinePoints, basePlate, scale, ...)`
-- `src/text3d.js`
+- `src/text/placement.ts`
   - currently picks a text placement area from either:
     - the **bounding box of the largest hole** (`getPrimaryPlacement`), or
     - a **fallback strip near the lower-left edge** (`getFallbackPlacement`)
@@ -463,7 +463,7 @@ But centered multiline should be the default.
 
 ## Why the current implementation is too limited
 
-Current `src/text3d.js` behavior is intentionally simple:
+Current `src/text/placement.ts` behavior is intentionally simple:
 
 - pick the largest hole by polygon area
 - use its axis-aligned bounding box if large enough
@@ -686,7 +686,7 @@ But that should be driven by concrete failures, not by theory-first ambition.
 
 ## Suggested implementation details against current files
 
-## `src/text3d.js`
+## `src/text/placement.ts`
 
 This is the natural home for the placement stage, but it should be split conceptually:
 

--- a/docs/text-placement-spec.md
+++ b/docs/text-placement-spec.md
@@ -2,7 +2,7 @@
 
 _Version 6 — updated 2026-04-02_
 
-This document describes the text placement pipeline used to emboss a circuit name onto the base plate of a 3D model. It is the authoritative spec for `src/text3d.js`.
+This document describes the text placement pipeline used to emboss a circuit name onto the base plate of a 3D model. It is the authoritative spec for the `src/text/` pipeline (the `src/text/index.ts` barrel, with placement/scaling in `src/text/placement.ts` and mesh building in `src/text/mesh.ts`).
 
 ---
 
@@ -16,7 +16,7 @@ The label is placed by:
 4. **Fitting text** into every candidate and scoring each (candidate × fit) pair.
 5. Returning the best-scoring pair as rank 1, second-best as rank 2, and so on.
 
-The pipeline runs fully at build/preview time in `src/text3d.js`.
+The pipeline runs fully at build/preview time in `src/text/` (entry point: `src/text/index.ts`).
 
 ---
 

--- a/src/components/OptionsPanel.svelte
+++ b/src/components/OptionsPanel.svelte
@@ -10,7 +10,7 @@
   } from '../stores/options.js';
   import { selectedTrack, layouts } from '../stores/track.js';
   import { normalizePrimaryOrientationDeg } from '../model/orientation.js';
-  import { normalizeTextPositionRank, DEFAULT_TEXT_POSITION_RANK } from '../text3d.js';
+  import { normalizeTextPositionRank, DEFAULT_TEXT_POSITION_RANK } from '../text/index.js';
   import { rebuildModel, loadElevations, invalidatePlacementCache } from '../track-loader.js';
   import { MIN_COASTER_TRACK_WIDTH_MM } from '../model/track-ribbon.js';
   import { get } from 'svelte/store';

--- a/src/model/orientation.ts
+++ b/src/model/orientation.ts
@@ -1,5 +1,5 @@
 import { buildBasePlate, buildTrackOutline as _buildTrackOutline } from '../geometry/outline.js';
-import { computeRankedTextPlacements, SCORING_WEIGHTS } from '../text3d.js';
+import { computeRankedTextPlacements, SCORING_WEIGHTS } from '../text/index.js';
 import type { OutlinePoints, BasePlate } from '../types/model.js';
 import type { Point2D, ProjectedNode } from '../types/geometry.js';
 import type { RankedPlacements } from '../types/text.js';

--- a/src/model/track-model.ts
+++ b/src/model/track-model.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_TEXT_POSITION_RANK,
   normalizeTextPositionRank,
   TEXT_HEIGHT_MM,
-} from '../text3d.js';
+} from '../text/index.js';
 import type { TrackModel, OutlinePoints, BasePlate } from '../types/model.js';
 import type { ProjectedNode } from '../types/geometry.js';
 import type { RankedPlacements } from '../types/text.js';

--- a/src/stores/options.ts
+++ b/src/stores/options.ts
@@ -4,7 +4,7 @@
 
 import { writable, derived } from 'svelte/store';
 import { selectPrintedTrackName } from '../search/index.js';
-import { DEFAULT_TEXT_POSITION_RANK } from '../text3d.js';
+import { DEFAULT_TEXT_POSITION_RANK } from '../text/index.js';
 import { selectedTrack, layouts, layoutIndex, osmVenueNames } from './track.js';
 
 /** Primary orientation of the model in degrees, or 'auto'. */

--- a/src/text/debug.ts
+++ b/src/text/debug.ts
@@ -1,53 +1,61 @@
 /**
- * Thin re-export shim for the src/text/ module group.
+ * Test-only debug helpers for the src/text/ module group.
  *
- * This file previously contained all 1585 lines of the text placement and
- * mesh generation pipeline. Those have been decomposed into focused modules
- * under src/text/. This shim re-exports the public API so that existing
- * callers (src/model/, src/main.ts, tests) continue to work unchanged.
- *
- * The src/text/ modules are still plain .js — their .d.ts files only declare
- * the public API. Internal helpers are accessed via `any` casts.
+ * These `__`-prefixed wrappers expose internal pipeline functions to the test
+ * suite without polluting the stable public API barrel (src/text/index.ts).
+ * Production code should never import from this module.
  */
 
-import type { OutlinePoints, BasePlate } from './types/model.js';
-import type { RankedPlacements, ScoringWeights, TextPlacementCandidate, RankedTextPlacement } from './types/text.js';
-import type { Point2D } from './types/geometry.js';
-// --- Internal module access (text/* modules are still .js — use any for internals) ---
-import * as _placementMod from './text/placement.js';
-import * as _contoursMod from './text/contours.js';
-import * as _lineBreakingMod from './text/line-breaking.js';
-import * as _scoringMod from './text/scoring.js';
-import * as _meshMod from './text/mesh.js';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const P = _placementMod as any; // internal exports not in .d.ts
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const C = _contoursMod as any; // internal exports not in .d.ts
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const LB = _lineBreakingMod as any; // internal exports not in .d.ts
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const SC = _scoringMod as any; // internal exports not in .d.ts
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const M = _meshMod as any; // internal exports not in .d.ts
-// --- Public API re-exports ---
-export {
-  TEXT_HEIGHT_MM,
-  DEFAULT_TEXT_POSITION_RANK,
-  normalizeTextPositionRank,
-  buildTextMeshFromRankedPlacements,
-} from './text/mesh.js';
-
-export { SCORING_WEIGHTS } from './text/scoring.js';
-
-export { computeRankedTextPlacements } from './text/placement.js';
+import type { Font } from 'opentype.js';
+import type { OutlinePoints, BasePlate } from '../types/model.js';
+import type {
+  ScoringWeights,
+  TextPlacementCandidate,
+  RankedTextPlacement,
+  FittedTextLayout,
+  Rect2D,
+  PlacementScoreBreakdown,
+} from '../types/text.js';
+import type { Point2D } from '../types/geometry.js';
+import {
+  computeRankedTextPlacements,
+  compareRankedTextPlacements,
+  scaleOutline,
+  createScaledBounds,
+  computePlacementMask,
+  findPlacementCandidates,
+  rectIntersectsPolygon,
+  dedupeRankedPlacements,
+  __resetPerfCounters as resetPlacementCounters,
+  __getPerfCounters as getPlacementCounters,
+  __disablePerfCounters as disablePlacementCounters,
+  type ComputeRankedOptions,
+} from './placement.js';
+import {
+  __resetPerfCounters as resetContoursCounters,
+  __getPerfCounters as getContoursCounters,
+  __disablePerfCounters as disableContoursCounters,
+} from './contours.js';
+import {
+  findOptimalLineBreaksForText,
+  __resetPerfCounters as resetLineBreakingCounters,
+  __getPerfCounters as getLineBreakingCounters,
+  __disablePerfCounters as disableLineBreakingCounters,
+} from './line-breaking.js';
+import {
+  scoreTextFit,
+  computeSizeWindowMultiplier,
+  computeLineCountMultiplier,
+  SCORING_WEIGHTS,
+} from './scoring.js';
+import { selectAndExpandPlacement } from './mesh.js';
 
 // --- Performance counter aggregation across all sub-modules ---
 
 export function __resetPerfCounters(): void {
-  (P.__resetPerfCounters as () => void)();
-  (C.__resetPerfCounters as () => void)();
-  (LB.__resetPerfCounters as () => void)();
+  resetPlacementCounters();
+  resetContoursCounters();
+  resetLineBreakingCounters();
 }
 
 interface PerfCounters {
@@ -60,9 +68,9 @@ interface PerfCounters {
 }
 
 export function __getPerfCounters(): PerfCounters | null {
-  const placement = (P.__getPerfCounters as () => Record<string, number> | null)();
-  const contours = (C.__getPerfCounters as () => Record<string, number> | null)();
-  const lineBreaking = (LB.__getPerfCounters as () => Record<string, number> | null)();
+  const placement = getPlacementCounters();
+  const contours = getContoursCounters();
+  const lineBreaking = getLineBreakingCounters();
   if (!placement && !contours && !lineBreaking) {
     return null;
   }
@@ -77,9 +85,9 @@ export function __getPerfCounters(): PerfCounters | null {
 }
 
 export function __disablePerfCounters(): void {
-  (P.__disablePerfCounters as () => void)();
-  (C.__disablePerfCounters as () => void)();
-  (LB.__disablePerfCounters as () => void)();
+  disablePlacementCounters();
+  disableContoursCounters();
+  disableLineBreakingCounters();
 }
 
 // ─── Private helpers ──────────────────────────────────────────────────────────
@@ -107,15 +115,15 @@ function computeTextPlacement(
   outlinePoints: OutlinePoints | null | undefined,
   basePlate: BasePlate,
   scale: number,
-  options: Record<string, unknown> = {},
+  options: ComputeRankedOptions & { textPositionRank?: number } = {},
 ): (ExpandedPlacement & { normalizedText: string }) | null {
   const normalizedText = String(text ?? '').trim();
   if (!normalizedText) {
     return null;
   }
 
-  const rankedResult = (P.computeRankedTextPlacements as (...a: unknown[]) => RankedPlacements | null)(text, outlinePoints, basePlate, scale, options);
-  const expanded = (M.selectAndExpandPlacement as (r: unknown, opts: unknown) => ExpandedPlacement | null)(rankedResult, options);
+  const rankedResult = computeRankedTextPlacements(text, outlinePoints, basePlate, scale, options);
+  const expanded = selectAndExpandPlacement(rankedResult, options);
   if (!expanded) {
     return null;
   }
@@ -129,16 +137,16 @@ export function __findOptimalLineBreaks(
   text: string,
   lineCount: number,
   font: unknown,
-): unknown {
-  return (LB.findOptimalLineBreaksForText as (t: string, n: number, f: unknown) => unknown)(text, lineCount, font ?? null);
+): string[] {
+  return findOptimalLineBreaksForText(text, lineCount, (font ?? null) as Font);
 }
 
 export function __debugScoreTextFit(
-  rect: { minX: number; minY: number; maxX: number; maxY: number; width: number; height: number },
-  layout: Record<string, unknown>,
-  candidate: Record<string, unknown> = {},
-): { score: number; breakdown: Record<string, number> } {
-  return (SC.scoreTextFit as (...a: unknown[]) => { score: number; breakdown: Record<string, number> })(rect, layout, candidate);
+  rect: Rect2D,
+  layout: FittedTextLayout,
+  candidate: { fractionOutside?: number; normalizedTrackClearance?: number } = {},
+): { score: number; breakdown: PlacementScoreBreakdown } {
+  return scoreTextFit(rect, layout, candidate);
 }
 
 export function __debugTextFitModifiers(
@@ -146,10 +154,10 @@ export function __debugTextFitModifiers(
   lineCount: number,
   fractionOutside = 1,
 ): { sizeWindowMultiplier: number; lineCountMultiplier: number; outsideMultiplier: number } {
-  const weights = SC.SCORING_WEIGHTS as ScoringWeights;
+  const weights: ScoringWeights = SCORING_WEIGHTS;
   return {
-    sizeWindowMultiplier: (SC.computeSizeWindowMultiplier as (h: number) => number)(heightMm),
-    lineCountMultiplier: (SC.computeLineCountMultiplier as (n: number) => number)(lineCount),
+    sizeWindowMultiplier: computeSizeWindowMultiplier(heightMm),
+    lineCountMultiplier: computeLineCountMultiplier(lineCount),
     outsideMultiplier: weights.outsideMultiplierMin + weights.outsideMultiplierRange * clamp(fractionOutside, 0, 1),
   };
 }
@@ -158,7 +166,7 @@ export function __debugCompareRankedTextPlacements(
   a: RankedTextPlacement,
   b: RankedTextPlacement,
 ): number {
-  return (P.compareRankedTextPlacements as (a: unknown, b: unknown) => number)(a, b);
+  return compareRankedTextPlacements(a, b);
 }
 
 export function __debugTextPlacement(
@@ -181,7 +189,13 @@ export function __debugTextPlacement(
   candidateFractionOutside: number | undefined;
   candidateTrackClearance: number | undefined;
 } | null {
-  const placement = computeTextPlacement(text, outlinePoints, basePlate, scale, options);
+  const placement = computeTextPlacement(
+    text,
+    outlinePoints,
+    basePlate,
+    scale,
+    options as ComputeRankedOptions & { textPositionRank?: number },
+  );
   if (!placement) {
     return null;
   }
@@ -207,22 +221,25 @@ export function __debugPlacementCandidates(
   basePlate: BasePlate,
   scale: number,
 ): TextPlacementCandidate[] {
-  const scaledOutline = (P.scaleOutline as (o: unknown, s: number) => unknown)(outlinePoints, scale);
-  const scaledBasePlate = (P.createScaledBounds as (b: unknown, s: number) => unknown)(basePlate, scale);
-  const placementMask = (P.computePlacementMask as (...a: unknown[]) => unknown)([scaledOutline], scaledOutline, scaledBasePlate);
-  return (P.findPlacementCandidates as (...a: unknown[]) => { candidates: TextPlacementCandidate[] })(scaledBasePlate, placementMask).candidates;
+  const scaledOutline = scaleOutline(outlinePoints, scale);
+  const scaledBasePlate = createScaledBounds(basePlate, scale);
+  const placementMask = computePlacementMask([scaledOutline], scaledOutline, scaledBasePlate);
+  return findPlacementCandidates(scaledBasePlate, placementMask).candidates;
 }
 
 export function __debugRectIntersectsPolygon(
   rect: { minX: number; minY: number; maxX: number; maxY: number },
   polygon: Point2D[],
 ): boolean {
-  return (P.rectIntersectsPolygon as (r: unknown, p: unknown) => boolean)(rect, polygon);
+  return rectIntersectsPolygon(
+    { ...rect, width: rect.maxX - rect.minX, height: rect.maxY - rect.minY },
+    polygon,
+  );
 }
 
 export function __debugDedupeRankedPlacements(
   placements: RankedTextPlacement[],
   scaledBasePlate: { minX: number; minY: number; maxX: number; maxY: number; width: number; height: number },
 ): RankedTextPlacement[] {
-  return (P.dedupeRankedPlacements as (p: unknown, b: unknown) => RankedTextPlacement[])(placements, scaledBasePlate);
+  return dedupeRankedPlacements(placements, scaledBasePlate);
 }

--- a/src/text/placement.ts
+++ b/src/text/placement.ts
@@ -873,7 +873,7 @@ export function dedupeRankedPlacements(
 }
 
 /** Options for computeRankedTextPlacements(). */
-interface ComputeRankedOptions {
+export interface ComputeRankedOptions {
   font?: import('opentype.js').Font | null;
   allOutlinePoints?: OutlinePoints[] | null;
   perfTimer?: PerfTimer | undefined;

--- a/src/track-loader.ts
+++ b/src/track-loader.ts
@@ -10,7 +10,7 @@ import { projectNodes } from './geometry/projection.js';
 import { fetchElevations } from './elevation/terrarium.js';
 import { createModelWorkerClient } from './workers/model-client.js';
 import { PRIMARY_ORIENTATION_AUTO } from './model/orientation.js';
-import { DEFAULT_TEXT_POSITION_RANK } from './text3d.js';
+import { DEFAULT_TEXT_POSITION_RANK } from './text/index.js';
 import { selectedTrack, layouts, layoutIndex, osmVenueNames } from './stores/track.js';
 import {
   currentModel,

--- a/src/types/text.ts
+++ b/src/types/text.ts
@@ -150,7 +150,7 @@ export interface RankedPlacements {
 /**
  * The tuning surface for the text placement scoring pipeline.
  * All magic numbers are collected here so they can be seen — and adjusted — in one place.
- * Shape mirrors the frozen `SCORING_WEIGHTS` object in `text3d.js`.
+ * Shape mirrors the frozen `SCORING_WEIGHTS` object in `src/text/scoring.ts`.
  */
 export interface ScoringWeights {
   /** Minimum multiplier when the candidate is fully inside the track outline. */

--- a/test/perf-build-track-outline.test.ts
+++ b/test/perf-build-track-outline.test.ts
@@ -12,7 +12,7 @@ import {
   __resetPerfCounters,
   __getPerfCounters,
   __disablePerfCounters,
-} from '../src/text3d.js';
+} from '../src/text/debug.js';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/test/perf-text-layout.test.ts
+++ b/test/perf-text-layout.test.ts
@@ -7,8 +7,8 @@ import {
   __resetPerfCounters,
   __getPerfCounters,
   __disablePerfCounters,
-  computeRankedTextPlacements,
-} from '../src/text3d.js';
+} from '../src/text/debug.js';
+import { computeRankedTextPlacements } from '../src/text/index.js';
 
 // ---------------------------------------------------------------------------
 // Helpers — realistic track shapes

--- a/test/placement-dedup.test.ts
+++ b/test/placement-dedup.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { __debugDedupeRankedPlacements } from '../src/text3d.js';
+import { __debugDedupeRankedPlacements } from '../src/text/debug.js';
 import type { RankedTextPlacement, Rect2D } from '../src/types/text.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/test/text-placement.test.ts
+++ b/test/text-placement.test.ts
@@ -8,7 +8,6 @@ import type { OutlinePoints, BasePlate, Triangle } from '../src/types/model.js';
 import { BASE_THICKNESS_MM } from '../src/model/index.js';
 import { rotateOutlineByOrientation } from '../src/model/orientation.js';
 import {
-  TEXT_HEIGHT_MM,
   __debugTextPlacement,
   __debugTextFitModifiers,
   __debugScoreTextFit,
@@ -16,8 +15,8 @@ import {
   __debugPlacementCandidates,
   __debugRectIntersectsPolygon,
   __findOptimalLineBreaks,
-  computeRankedTextPlacements,
-} from '../src/text3d.js';
+} from '../src/text/debug.js';
+import { TEXT_HEIGHT_MM, computeRankedTextPlacements } from '../src/text/index.js';
 import { buildTextMeshFromRankedPlacements } from '../src/text/mesh.js';
 
 type Point = { x: number; y: number };


### PR DESCRIPTION
## Summary

Implements the approved plan for #137: remove the legacy `src/text3d.ts` compatibility shim and consolidate everything onto the `src/text` barrel.

This is a **pure refactor — no behavior change.**

- `src/text3d.ts` is deleted; its debug-only helpers move to `src/text/debug.ts`.
- All consumers are repointed from `../text3d.js` to the `src/text` barrel (`src/text/index.js`): `src/components/OptionsPanel.svelte`, `src/model/orientation.ts`, `src/model/track-model.ts`, `src/stores/options.ts`, `src/track-loader.ts`, `src/types/text.ts`.
- The text-placement test is renamed `test/text3d.test.ts` -> `test/text-placement.test.ts` to match the module it covers; the relocated `__debug*` / perf-counter helpers are exercised by the perf-text-layout, perf-build-track-outline, and placement-dedup tests (all green).
- Doc/skill references updated (architecture + testing skills under `.claude/skills` and `.agents/skills`, plus `docs/text-placement-research.md` and `docs/text-placement-spec.md`).

## API change

A single new export — `ComputeRankedOptions` — is now surfaced from `src/text/placement.ts` (previously only reachable via the shim). No other API or runtime logic changes.

## Verification

- `npm run build`: green
- `npm run typecheck` (`tsc --noEmit`): clean, 0 errors, no new `any`
- `npm run lint`: no new errors. One pre-existing `no-implicit-coercion` error in `src/model/track-model.ts:174` is present identically on `main` (verified by linting the committed file content) and is untouched by this refactor.
- `npm test`: **196 tests / 196 pass / 0 fail / 0 skipped** (exit 0).
- `grep -rn "text3d" src test docs .claude/skills .agents/skills` is empty.

### Note on the mesh-test baseline

The full suite is now entirely green. The three mesh/manifold tests that were previously intentional-red (`representative sample meshes are 2-manifold...` and the two flush-coaster 2-manifold assertions) were turned green by the earlier #133/#134 merge ("Unify all model generation on manifold-3d CSG"), which fixed the underlying geometry and tightened the assertions to `=== 0`. The test files document this directly ("GREEN AS OF #133"). This refactor does not touch those test or model files beyond two import-line changes in `src/model/`, so the green state is inherited from `main` HEAD and is not caused by this change.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
