### PR TITLE
feat(validate): stream progress during validate:meshes --all

### DIFF
--- a/scripts/validate-meshes.ts
+++ b/scripts/validate-meshes.ts
@@ -103,7 +103,23 @@ async function main(): Promise<void> {
     const ids = buildableTrackIds();
     console.log(`validate:meshes — all ${ids.length} buildable tracks (lean matrix). This may take minutes.\n`);
     const started = Date.now();
-    const result = await runSweep(ids, { variant: 'all' });
+    let lastBeat = 0;
+    const result = await runSweep(ids, {
+      variant: 'all',
+      onProgress: p => {
+        // Stream each failing track the moment it is found.
+        if (p.trackFailures > 0) {
+          console.log(`  ✗ ${p.trackId}: ${p.trackFailures} failing row(s)  [${p.processed}/${p.total}]`);
+        }
+        // Heartbeat every 25 tracks (and on the final track) so a long run shows progress.
+        if (p.processed - lastBeat >= 25 || p.processed === p.total) {
+          lastBeat = p.processed;
+          const rate = p.processed / Math.max(1, p.elapsedMs / 1000);
+          const etaS = rate > 0 ? Math.round((p.total - p.processed) / rate) : 0;
+          console.log(`  … ${p.processed}/${p.total} processed · ${p.built} built · ${p.failures} failing rows · ${(p.elapsedMs / 1000).toFixed(0)}s elapsed · ~${etaS}s left`);
+        }
+      },
+    });
     console.log(`(${((Date.now() - started) / 1000).toFixed(1)}s)\n`);
     report(result, ids.length);
     return;

--- a/test-utils/mesh-sweep.ts
+++ b/test-utils/mesh-sweep.ts
@@ -324,9 +324,28 @@ export interface SweepResult {
   skipped: { trackId: string; reason: 'no-geometry' }[];
 }
 
+export interface SweepProgress {
+  /** Tracks processed so far (built + skipped). */
+  processed: number;
+  /** Total tracks in this run. */
+  total: number;
+  /** Tracks built so far (excludes skipped). */
+  built: number;
+  /** Cumulative failing rows so far. */
+  failures: number;
+  /** Milliseconds elapsed since the sweep started. */
+  elapsedMs: number;
+  /** The track id just processed. */
+  trackId: string;
+  /** Failing rows contributed by the track just processed (0 when clean/skipped). */
+  trackFailures: number;
+}
+
 export interface RunSweepOptions {
   /** Selects the per-track mode matrix. Defaults to 'sample'. */
   variant?: SweepVariant;
+  /** Optional callback invoked once per track (built or skipped) for progress reporting. */
+  onProgress?: (progress: SweepProgress) => void;
 }
 
 /**
@@ -335,22 +354,31 @@ export interface RunSweepOptions {
  */
 export async function runSweep(trackIds: string[], options: RunSweepOptions = {}): Promise<SweepResult> {
   const variant = options.variant ?? 'sample';
+  const { onProgress } = options;
   const failures: SweepFailure[] = [];
   const skipped: SweepResult['skipped'] = [];
   let built = 0;
+  let processed = 0;
+  const startedAt = Date.now();
+  const total = trackIds.length;
 
   for (const trackId of trackIds) {
     const file = readTrackFile(trackId);
     if (file === null || !isBuildable(file)) {
       skipped.push({ trackId, reason: 'no-geometry' });
+      processed += 1;
+      onProgress?.({ processed, total, built, failures: failures.length, elapsedMs: Date.now() - startedAt, trackId, trackFailures: 0 });
       continue;
     }
     const multiLayout = buildableLayouts(file).length > 1;
     const modes = enumerateModes(multiLayout, variant);
+    const before = failures.length;
     for (const mode of modes) {
       failures.push(...await sweepOne(file, mode));
     }
     built += 1;
+    processed += 1;
+    onProgress?.({ processed, total, built, failures: failures.length, elapsedMs: Date.now() - startedAt, trackId, trackFailures: failures.length - before });
   }
 
   return { failures, built, skipped };


### PR DESCRIPTION
## What
Streams progress during the long `npm run validate:meshes -- --all` corpus sweep:
- a line for **each failing track the moment it's found** — `✗ <id>: N failing row(s) [k/total]`
- a **heartbeat every 25 tracks** — `… k/total processed · built · failing rows · elapsed · ~ETA left`

## Why
The full corpus sweep is **649 tracks / ~90 min**. It previously produced no output until the final verdict, so a long run was indistinguishable from a hang and offered no way to spot a regression trend early. This surfaced while investigating the #125 mesh-baseline tail — a 90-minute black-box run is painful to operate against.

## How
- `runSweep()` gains an optional `onProgress` callback (new `SweepProgress` shape), invoked once per track (built or skipped). **Purely additive**: the callback defaults to `undefined`, `SweepResult` is unchanged, and the test-suite callers of `runSweep()` are unaffected.
- The `--all` CLI branch passes a callback that streams failures + throttled heartbeats. `--track` and the representative-sample run are unchanged.

## Verification
- `tsc --noEmit`: 0 errors.
- `eslint scripts/ test-utils/` (changed files): clean.
- Smoke-tested the callback on a 3-track run: streams the per-failure line + heartbeat with correct counts/elapsed.
- No behaviour change to `SweepResult`, so existing `runSweep()` consumers (the mesh-sweep tests) are unaffected.

Tooling only — no product/geometry change. Part of #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
